### PR TITLE
Fixed: paused loops start because 'on end' timer is not cleared

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -367,12 +367,13 @@
         return self;
       }
 
-      // clear 'onend' timer
-      var timer = self._onendTimer.indexOf(timerId);
-      if (timer >= 0) {
-        clearTimeout(self._onendTimer[timer]);
-        self._onendTimer.splice(timer, 1);
+      // always clear 'onend' timer
+      var timer = self._onendTimer.length - 1;
+      if (timerId) {
+        timer = self._onendTimer.indexOf(timerId);
       }
+      clearTimeout(self._onendTimer[timer]);
+      self._onendTimer.splice(timer, 1);
 
       if (self._webAudio) {
         // make sure the sound has been created


### PR DESCRIPTION
This fix makes sure the last 'on end' timer is cleared when a sound is paused. You don't want these firing when your sound is paused, especially if it's set to loop.
