### PR TITLE
Feature detection for w3c

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -349,7 +349,13 @@
         refreshBuffer(self);
 
         self._playStart = ctx.currentTime;
-        self.bufferSource.noteGrainOn(0, pos, duration);
+        // webkit
+        if (typeof self.bufferSource.noteGrainOn !== 'undefined') {
+          self.bufferSource.noteGrainOn(0, pos, duration);  
+        }
+        else { // w3c spec
+          self.bufferSource.start(0, pos, duration);
+        }        
       } else {
         self._inactiveNode(function(node) {
           if (node.readyState === 4) {
@@ -452,7 +458,13 @@
           return self;
         }
 
-        self.bufferSource.noteOff(0);
+        if (typeof self.bufferSource.noteOff !== 'undefined') {
+          self.bufferSource.noteOff(0);  
+        }
+        else {
+          self.bufferSource.stop(0);
+        }
+        
       } else {
         var activeNode = self._activeNode();
 


### PR DESCRIPTION
This is a first crack at making Howler aware of Firefox's more spec-compliant implementation of the w3c We Audio Api spec. There are a number of changes to the spec discussed in the deprecation section that webkit hasn't implemented:

https://dvcs.w3.org/hg/audio/raw-file/tip/webaudio/specification.html#DeprecationNotes

Because Mozilla is implementing the spec right now, the current spec is being followed.

Note: you will need to download Firefox Nightly ( https://nightly.mozilla.org ) in order for any of this to work at all currently, and there are a number of bugs that need to be resolved for it to work well. The tracking bug is here:

https://bugzilla.mozilla.org/show_bug.cgi?id=779297
