### PR TITLE
Exit on browsers with no audio support

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -23,6 +23,11 @@
     usingWebAudio = false;
   }
 
+  // Bail out silently on older browsers
+  if ( !usingWebAudio && typeof Audio === "undefined" ) {
+    return;
+  }
+
   // create a master gain node
   if (usingWebAudio) {
     var gainNode = (typeof ctx.createGain === 'undefined') ? ctx.createGainNode() : ctx.createGain();


### PR DESCRIPTION
This patch is a simple bail out of the module if the browser has no Audio support of any kind (e.g. IE 8 and other older browsers). 

When the module loads it initially runs "new Audio()" without checking (around line 134) , what causes older browser to  crash here. My patch adds a simple exit strategy to avoid this. 

However, it leaves "Howl" and "Howler" undefined and that may not be a good thing either, but moves the error handling to the user´s code. 

Cheers,
Michael
