### PR TITLE
Notifying users when the sound could not be loaded

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -161,6 +161,7 @@
 
     // setup event functions
     self._onload = [o.onload || function() {}];
+    self._onloaderror = [o.onloaderror || function() {}];
     self._onend = [o.onend || function() {}];
     self._onpause = [o.onpause || function() {}];
     self._onplay = [o.onplay || function() {}];
@@ -192,6 +193,7 @@
 
       // if no audio is available, quit immediately
       if (noAudio) {
+        self.on('loaderror');
         return;
       }
 
@@ -232,6 +234,7 @@
       }
 
       if (!url) {
+        self.on('loaderror');
         return;
       }
 


### PR DESCRIPTION
A function can be passed as parameter to the property onloaderror,
in the Howl constructor.
Sometimes the user need to know if there was some error when trying to load
the sound, so he can take an action.

Signed-off-by: Thiago de Barros Lacerda thiago.lacerda@openbossa.org
