### PR TITLE
Allow passing the file format as a property.

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -151,6 +151,7 @@
     self._autoplay = o.autoplay || false;
     self._buffer = o.buffer || false;
     self._duration = o.duration || 0;
+    self._format = o.format || null;
     self._loop = o.loop || false;
     self._loaded = false;
     self._sprite = o.sprite || {};
@@ -202,6 +203,11 @@
 
         // figure out the filetype (whether an extension or base64 data)
         ext = (ext && ext.length >= 2) ? ext[1] : self._urls[i].toLowerCase().match(/data\:audio\/([^?]+);/)[1];
+
+        // set audio file format if specified
+        if (self._format) {
+          ext = self._format;
+        }
 
         switch (ext) {
           case 'mp3':


### PR DESCRIPTION
Currently you detect the audio file format from the file extension, which makes a lot of sense. I'd like to be able to also load sounds that don't follow that convention by specifying the format. For example, I make an API request that returns an mp3 file however it does not end with .mp3 in the url. Such as:

```
var sound = new Howl({
  urls: ['http://webservice/awesome?query=hello'],
  format: 'mp3'
});
```
