### PR TITLE
Update AMD define to export Howler and Howl as single module.

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -128,7 +128,7 @@
   };
 
   // allow access to the global audio controls
-  window.Howler = new HowlerGlobal();
+  var Howler = new HowlerGlobal();
 
   // check for browser codec support
   var audioTest = null;
@@ -144,7 +144,7 @@
   }
 
   // setup the audio object
-  var Howl = window.Howl = function(o) {
+  var Howl = function(o) {
     var self = this;
 
     // setup the defaults
@@ -1117,11 +1117,13 @@
    */
   if (typeof define === 'function' && define.amd) {
     define('Howler', function() {
-      return Howler;
+      return {
+        Howler: Howler,
+        Howl: Howl
+      };
     });
-
-    define('Howl', function() {
-      return Howl;
-    });
+  } else {
+    window.Howler = Howler;
+    window.Howl = Howl;
   }
 })();


### PR DESCRIPTION
It is recommended to only define one module per file. See http://requirejs.org/docs/api.html#define

Currently there are two modules defined, and Howl requires Howler to work. So as currently implemented you would always have to include both modules. I've made an update that will export both Howler and Howl as a single AMD module.

Also, when you load Howler as an AMD module, ideally the Howler and Howl are no longer in the global namespace.
