### PR TITLE
Make `node.play` async when not using webAudio

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -396,7 +396,7 @@
             node.currentTime = pos;
             node.muted = Howler._muted;
             node.volume = self._volume * Howler.volume();
-            node.play();
+            setTimeout(function() { node.play(); }, 0);
           } else {
             self._clearEndTimer(timerId);
 


### PR DESCRIPTION
It took me half day to figure out why Howler is not working in the latest Firefox release. If I manually load the `.ogg` file in the browser, Howler.play works beautifully but if the file is not loaded, there was no sound coming out. 

By wrapping the `node.play` in a `setTimeout(func, 0)` wrapper, we force the `play` event to wait till the current loading event is finished. 

Please note that Firefox's default setting for `media.webaudio.enabled` is `false`, which is why `self._webAudio` code path wasn't selected.
