### PR TITLE
Change AMD definition to anonymous module. Close #65.

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -1165,17 +1165,19 @@
   }
 
   /**
-   * Add support for AMD (Async Module Definition) libraries such as require.js.
+   * Add support for AMD (Asynchronous Module Definition) libraries such as require.js.
    */
   if (typeof define === 'function' && define.amd) {
-    define('Howler', function() {
+    define(function() {
       return {
         Howler: Howler,
         Howl: Howl
       };
     });
-  } else {
-    window.Howler = Howler;
-    window.Howl = Howl;
   }
+  
+  // define globally in case AMD is not available or available but not used
+  window.Howler = Howler;
+  window.Howl = Howl;
+  
 })();


### PR DESCRIPTION
Change AMD definition to create anonymous module rather than named and
create global objects whether AMD is available or not.
