### PR TITLE
Bugfix: search with dots in url now works correctly

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -214,29 +214,29 @@
       // loop through source URLs and pick the first one that is compatible
       for (var i=0; i<self._urls.length; i++) {
         
-				var ext, urlItem;
+        var ext, urlItem;
 
-				if (self._format) {
-					// use specified audio format if available
-					ext = self._format;
-				} else {
-					urlItem = self._urls[i].toLowerCase();
-					// figure out the filetype (whether an extension or base64 data), with removing search
-					ext = urlItem.match(/([^?]+)[\?]?.+/);
-					if (ext && ext.length > 1) {
-						ext = ext[1].match(/.+\.([^?]+)(\?|$)/);
-						if (ext && ext.length >= 2) {
-							ext = ext[1];
-						} else {
-							ext = null;
-						}
-					} else {
-						ext = null;
-					}
-					if (ext == null) {
-						ext = urlItem.match(/data\:audio\/([^?]+);/)[1];
-					}
-				}
+        if (self._format) {
+          // use specified audio format if available
+          ext = self._format;
+        } else {
+          urlItem = self._urls[i].toLowerCase();
+          // figure out the filetype (whether an extension or base64 data), with removing search
+          ext = urlItem.match(/([^?]+)[\?]?.+/);
+          if (ext && ext.length > 1) {
+            ext = ext[1].match(/.+\.([^?]+)(\?|$)/);
+            if (ext && ext.length >= 2) {
+              ext = ext[1];
+            } else {
+              ext = null;
+            }
+          } else {
+            ext = null;
+          }
+          if (ext == null) {
+            ext = urlItem.match(/data\:audio\/([^?]+);/)[1];
+          }
+        }
 
         if (canPlay[ext]) {
           url = self._urls[i];


### PR DESCRIPTION
Some url with dots in search parsed incorrectly (wrong extension used).

E.G. url "/audio/sound.ogg?build=0.13.95" was parsed as ".95" file, not ".ogg" file. It's totally incorrect and fixed by this commit
