### PR TITLE
callback must return the timerId

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -426,9 +426,9 @@
           }
         }
 
-        // fire the play event and send the soundId back in the callback
+        // fire the play event and send the soundId and timerId back in the callback
         self.on('play');
-        if (typeof callback === 'function') callback(soundId);
+        if (typeof callback === 'function') callback(soundId, timerId);
 
         return self;
       });


### PR DESCRIPTION
timerId is needed when you are running a sound in loop mode and need to be stopped later
