### PR TITLE
fixed compatibility with CocoonJS (launcher v1.4.7) 

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -257,7 +257,7 @@
             HowlerGlobal.noAudio = true;
           }
 
-          self.on('loaderror', {type: newNode.error.code});
+          self.on('loaderror', {type: newNode.error ? newNode.error.code : 0});
         }, false);
 
         self._audioNode.push(newNode);
@@ -421,7 +421,8 @@
             node.bufferSource.start(0, pos, duration);
           }
         } else {
-          if (node.readyState === 4) {
+          if (node.readyState === 4 || navigator.isCocoonJS) {
+            node.readyState = 4;
             node.id = soundId;
             node.currentTime = pos;
             node.muted = Howler._muted || node.muted;
@@ -924,7 +925,7 @@
       } else {
         self.load();
         newNode = self._audioNode[self._audioNode.length - 1];
-        newNode.addEventListener('loadedmetadata', function() {
+        newNode.addEventListener(navigator.isCocoonJS ? 'canplaythrough' : 'loadedmetadata', function() {
           callback(newNode);
         });
       }


### PR DESCRIPTION
Dear Goldfire team,

While integrating Howler as a replacement implementation for our Audio implementation in [melonJS](www.melonjs.org), we stumbled on a few compatibility issues when  testing/deploying games on mobile devices through CocoonJS, and here is then a pull request with the fixes we applied on our side.

We are not expecting you to maybe directly use this one (although it's doing the job), as I believe that at least for the `node.readyState` issue (see below) we are more providing a workaround than a real bug fix (as I think the issue is somewhere else), but  it should give you at least the right direction to look for an eventual better fix (if any)

So the reason we identified that were causing the issues are the following :
- CocoonJS does not support the `loadedmetadata` event, but only the `canplaythrough` and `ended` events
- `node.readyState` is undefined when using CocoonJS
- `newNode.error` is undefined when using CocoonJS

For more information : 
- Related discussion thread in the melonJS repository
  https://github.com/melonjs/melonJS/issues/470
- Ludei/CocoonJS supported Feature list 
  http://support.ludei.com/hc/en-us/articles/200807787-HTML5-feature-list

Finally, thank you very much for that great library, and keep up the good work !

-- the melonJS team
