### PR TITLE
Add .aac files support

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -147,6 +147,7 @@
       opus: !!audioTest.canPlayType('audio/ogg; codecs="opus"').replace(/^no$/, ''),
       ogg: !!audioTest.canPlayType('audio/ogg; codecs="vorbis"').replace(/^no$/, ''),
       wav: !!audioTest.canPlayType('audio/wav; codecs="1"').replace(/^no$/, ''),
+      aac: !!audioTest.canPlayType('audio/aac;').replace(/^no$/, ''),
       m4a: !!(audioTest.canPlayType('audio/x-m4a;') || audioTest.canPlayType('audio/aac;')).replace(/^no$/, ''),
       mp4: !!(audioTest.canPlayType('audio/x-mp4;') || audioTest.canPlayType('audio/aac;')).replace(/^no$/, ''),
       weba: !!audioTest.canPlayType('audio/webm; codecs="vorbis"').replace(/^no$/, '')


### PR DESCRIPTION
Tested in Safari 7 with [a file](http://download.wavetlan.com/SVV/Media/HTTP/AAC/Roxio_Media_Manager/RoxioMediaManager_test4_AAC-LC_v4_Stereo_CBR_64kbps_44100Hz.aac) found on [wavetlan](http://download.wavetlan.com/SVV/Media/HTTP/http-aac.htm)

Chrome doesn't support `audio/aac;` at all, tried `(new Audio()).canPlayType('audio/aac;')`
