### PR TITLE
Expose supported `codecs` with a new global method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ The following methods are used to modify all sounds globally, and are called fro
 * **unmute**: Unmutes all sounds and restores them to their previous volume.
 * **volume**: Get/set the global volume for all sounds.
   * *volume*: `Number` (optional) Volume from `0.0` to `1.0`.
+* **codecs**: Check supported audio codecs.
+  * *ext*: `String` File extension. One of: "mp3", "opus", "ogg", "wav", "aac", "m4a", "mp4", "weba".
 
 ## License
 

--- a/howler.js
+++ b/howler.js
@@ -48,12 +48,13 @@
   }
 
   // create global controller
-  var HowlerGlobal = function() {
+  var HowlerGlobal = function(codecs) {
     this._volume = 1;
     this._muted = false;
     this.usingWebAudio = usingWebAudio;
     this.noAudio = noAudio;
     this._howls = [];
+    this._codecs = codecs;
   };
   HowlerGlobal.prototype = {
     /**
@@ -132,17 +133,24 @@
           }
         }
       }
+    },
+
+    /**
+     * Check for codec support.
+     * @param  {String} ext Audio file extention.
+     * @return {Boolean}
+     */
+    codecs: function(ext) {
+      return this._codecs[ext];
     }
   };
 
-  // allow access to the global audio controls
-  var Howler = new HowlerGlobal();
-
   // check for browser codec support
   var audioTest = null;
+  var codecs = {};
   if (!noAudio) {
     audioTest = new Audio();
-    var codecs = {
+    codecs = {
       mp3: !!audioTest.canPlayType('audio/mpeg;').replace(/^no$/, ''),
       opus: !!audioTest.canPlayType('audio/ogg; codecs="opus"').replace(/^no$/, ''),
       ogg: !!audioTest.canPlayType('audio/ogg; codecs="vorbis"').replace(/^no$/, ''),
@@ -153,6 +161,9 @@
       weba: !!audioTest.canPlayType('audio/webm; codecs="vorbis"').replace(/^no$/, '')
     };
   }
+
+  // allow access to the global audio controls
+  var Howler = new HowlerGlobal(codecs);
 
   // setup the audio object
   var Howl = function(o) {


### PR DESCRIPTION
Sometimes it is useful to know which audio formats the browser is capable of playing. Howler already detects supported codecs and keeps this information internal. This patch exposes the supported codecs by adding a new getter method to the global `Howler` object.
