### PR TITLE
Fire 'onend' event when close is called.

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -632,6 +632,9 @@
           activeNode.currentTime = 0;
         }
       }
+      
+      // fire ended event
+      self.on('end', id);
 
       return self;
     },


### PR DESCRIPTION
If a node is still playing while `unload` is called, the `onend` event handler will not be fired. This patch makes sure that `stop` in general will fire the `end` event. 

Although this seems to have fixed the sympton for me, I am not 100% sure that this is the correct place to put it. It also feels a bit strange that I am the first one who runs into this problem. So please take this with a grain of salt.  
