### PR TITLE
Replace anonymous define with a named define.

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -1299,7 +1299,7 @@
    * Add support for AMD (Asynchronous Module Definition) libraries such as require.js.
    */
   if (typeof define === 'function' && define.amd) {
-    define(function() {
+    define('howler', function() {
       return {
         Howler: Howler,
         Howl: Howl


### PR DESCRIPTION
Without a name, the module name is unpredictable,
and unsuitable for bundling with other libraries in a single file.
