### PR TITLE
one can omit the second parameter in off

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -1137,8 +1137,9 @@
     off: function(event, fn) {
       var self = this,
         events = self['_on' + event],
-        fnString = fn.toString();
+        fnString = fn ? fn.toString() : '';
 
+        if(fnString != '') {
       // loop through functions in the event for comparison
       for (var i=0; i<events.length; i++) {
         if (fnString === events[i].toString()) {
@@ -1146,6 +1147,9 @@
           break;
         }
       }
+        } else {
+            self['_on' + event] = [];
+        }
 
       return self;
     },


### PR DESCRIPTION
In the docs: http://goldfirestudios.com/blog/104/howler.js-Modern-Web-Audio-Javascript-Library
it says:
off: Remove custom events that you've set.
    event: String Name of event.
    function: Function (optional) The listener to remove.
Well, specifying only the event name ['load', 'end' ...] would trigger an error because it tries to fn.toString() anyway.
This commit solves that so you now can do:
sound.on('end', function(){
  alert('sound ended');
});
and later:
sound.off('end');
and it removes ALL handlers you would have for that event.
