### PR TITLE
Push all method calls in a queue before load

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -229,6 +229,7 @@
     self._format = o.format || null;
     self._loop = o.loop || false;
     self._loaded = false;
+    self._beforeLoadQueue = [];
     self._sprite = o.sprite || {};
     self._src = o.src || '';
     self._pos3d = o.pos3d || [0, 0, -0.5];
@@ -361,6 +362,7 @@
 
           if (!self._loaded) {
             self._loaded = true;
+            self._drainBeforeLoadQueue();
             self.on('load');
           }
 
@@ -419,7 +421,7 @@
 
       // if the sound hasn't been loaded, add it to the event queue
       if (!self._loaded) {
-        self.on('load', function() {
+        self._queueBeforeLoad(function() {
           self.play(sprite, callback);
         });
 
@@ -556,7 +558,7 @@
 
       // if the sound hasn't been loaded, add it to the event queue
       if (!self._loaded) {
-        self.on('play', function() {
+        self._queueBeforeLoad(function() {
           self.pause(id);
         });
 
@@ -602,7 +604,7 @@
 
       // if the sound hasn't been loaded, add it to the event queue
       if (!self._loaded) {
-        self.on('play', function() {
+        self._queueBeforeLoad(function() {
           self.stop(id);
         });
 
@@ -648,7 +650,7 @@
 
       // if the sound hasn't been loaded, add it to the event queue
       if (!self._loaded) {
-        self.on('play', function() {
+        self._queueBeforeLoad(function() {
           self.mute(id);
         });
 
@@ -677,7 +679,7 @@
 
       // if the sound hasn't been loaded, add it to the event queue
       if (!self._loaded) {
-        self.on('play', function() {
+        self._queueBeforeLoad(function() {
           self.unmute(id);
         });
 
@@ -713,7 +715,7 @@
 
         // if the sound hasn't been loaded, add it to the event queue
         if (!self._loaded) {
-          self.on('play', function() {
+          self._queueBeforeLoad(function() {
             self.volume(vol, id);
           });
 
@@ -783,7 +785,7 @@
 
       // if the sound hasn't been loaded, add it to the event queue
       if (!self._loaded) {
-        self.on('load', function() {
+        self._queueBeforeLoad(function() {
           self.pos(pos);
         });
 
@@ -838,7 +840,7 @@
 
       // if the sound hasn't been loaded, add it to the event queue
       if (!self._loaded) {
-        self.on('play', function() {
+        self._queueBeforeLoad(function() {
           self.pos3d(x, y, z, id);
         });
 
@@ -879,7 +881,7 @@
 
       // if the sound hasn't been loaded, add it to the event queue
       if (!self._loaded) {
-        self.on('load', function() {
+        self._queueBeforeLoad(function() {
           self.fade(from, to, len, callback, id);
         });
 
@@ -1106,6 +1108,24 @@
     },
 
     /**
+     * Pushes fn in a queue. The methods will be called when _loaded == true.
+     * @param  {Function} fn   Function to queue.
+     */
+    _queueBeforeLoad: function(fn) {
+      this._beforeLoadQueue.push(fn);
+    },
+
+    /**
+     * Execute all queued functions.
+     */
+    _drainBeforeLoadQueue: function() {
+      var fn;
+      while ( (fn = this._beforeLoadQueue.shift()) ) {
+        fn();
+      }
+    },
+
+    /**
      * Call/set custom events.
      * @param  {String}   event Event type.
      * @param  {Function} fn    Function to call.
@@ -1292,6 +1312,7 @@
       // fire the loaded event
       if (!obj._loaded) {
         obj._loaded = true;
+        obj._drainBeforeLoadQueue();
         obj.on('load');
       }
 


### PR DESCRIPTION
Previously, when a method is called before the sound is loaded,
the method call would be added to an event queue, but NEVER
removed again. Consequently, when the sound is played again, the
queued method is called again.

Here is an example that demonstrates the consequences:

``` js
var h = new Howl({urls:['http://goldfirestudios.com/proj/howlerjs/sound.mp3']})
// Note: sound is not loaded, so the following is queued.
h.volume(1);
h.on('load', function() {
    h.volume(0);
    // Sound should be silent, but instead it is at volume 1!
    h.play();
})
```

This patch replaces the erroneous "on('load'," implementation with
new internal methods. When methods are called before the sound is
loaded, the methods are pushed on a queue. When the sound is ready,
the queue is drained in FIFO order.

This patch might fix #164 as well.

(Another way to fix the bug is by implementing an once() method which
adds an event listener to an event queue, and removes the listener
after calling the method one time. However the implementation of the
event emitter is terribly broken as I pointed out in #184, so I decided to use
a queue specific for this purpose.)
