### PR TITLE
Two oddities

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -961,7 +961,6 @@
           self.pause(id);
           sound._seek = seek;
           self._clearTimer(id);
-          self.play(id);
         } else {
           return (self._webAudio) ? sound._seek + (ctx.currentTime - sound._playStart) : sound._node.currentTime;
         }


### PR DESCRIPTION
In order for my project to work I needed to fix these two points.
1. The onpause event was not being fired.
2. On `seek()` the audio was always resuming playback. I am not sure if it supposed to in some situations but not in others, however in my code resuming playback was being done manually as opposed to relying on howler. So for me the solution was to simply remove the code calling for the audio to resume after `seek()`.

Submitting in the form of a pull request as unless I'm mistaken these were simply small but important omissions.
