### PR TITLE
Update bower.json for 2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "howler.js",
-  "version": "1.1.25",
+  "version": "2.0",
   "description": "Javascript audio library for the modern web.",
-  "main": "howler.js"
+  "main": "howler.min.js"
 }


### PR DESCRIPTION
Currently, installing v2.0 via Bower `bower i howler.js#2.0` causes an error due to outdated reference to main file (howler.js --> howler.min.js)