### PR TITLE
Update file sizes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ More documentation, examples and demos can be found at **[howlerjs.com](http://h
 * Fade in/out sounds
 * Supports Web Audio 3D sound positioning
 * Methods can be chained
-* Uses no outside libraries, just pure Javascript
-* Lightweight, 9kb filesize (3kb gzipped)
+* Uses no outside libraries, just pure JavaScript
+* Lightweight; 12kb minified filesize (4kb gzipped)
 
 ### Browser Compatibility
 Tested in the following browsers/versions:


### PR DESCRIPTION
- updated the minified and gzipped file sizes to match the current sizes
- label the filesize “minified” to be clear – the unminified filesize is 38kb
- improve grammar by using semicolon instead of comma
- fix capitalization of “JavaScript” nearby