### PR TITLE
Fixing Package.json to use the available file

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git://github.com/goldfire/howler.js.git"
   },
-  "main": "howler.js",
+  "main": "howler.min.js",
   "version": "1.1.25",
   "license": {
     "type": "MIT",


### PR DESCRIPTION
As it currently is you can't use NPM to install Howler 2.0 properly. 

NPM doesn't install `howler.js` so it's unavailable. The main property needs to be set to `howler.min.js`

P.S. using` "howler": "git+ssh://git@github.com:goldfire/howler.js.git#2.0",` in my package json to install as 2.0 isn't available on NPM yet.