### PR TITLE
Allow npm to install 2.0 branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git://github.com/goldfire/howler.js.git#2.0"
   },
-  "main": "howler.js",
+  "main": "howler.min.js",
   "version": "2.0.0-beta",
   "license": {
     "type": "MIT",


### PR DESCRIPTION
And use it as dependency without any extra build steps.