### PR TITLE
file format is now an array

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -292,9 +292,9 @@
       for (var i=0; i<self._urls.length; i++) {
         var ext, urlItem;
 
-        if (self._format) {
+        if (self._format[i]) {
           // use specified audio format if available
-          ext = self._format;
+          ext = self._format[i];
         } else {
           // figure out the filetype (whether an extension or base64 data)
           urlItem = self._urls[i];


### PR DESCRIPTION
This allows you to specify all the file formats for each of the files.  This can be useful of you want to manually change the extensions for your files. For example if your using CloudFlare and they don't cache music files you can change the extensions to .jpeg and then specify each of the file formats. 