### PR TITLE
Added Howl.one 

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -1155,6 +1155,23 @@
     },
 
     /**
+     * Fire event once then remove this handler.
+     * @param  {String}   event Event type.
+     * @param  {Function} fn    Listener to add then remove.
+     * @return {Howl}
+     */
+    one: function (event, fn) {
+      var self = this;
+
+      var wrapperfn = function () {
+        fn.apply(self, arguments);
+        self.off(event, fn);
+      };
+
+      return self.on(event, wrapperfn);
+    },
+
+    /**
      * Unload and destroy the current Howl object.
      * This will immediately stop all play instances attached to this sound.
      */


### PR DESCRIPTION
Causes an event listener to only fire once and then remove itself. Similar in spirit to jQuery.one.

    howl.one('end', function () {
      console.log("I'll only show up once, even if you play me again!");
    });

I'm not sure how minimalistic you'd like to keep the library, but I found this useful while designing a modular sound system that loops through the same files over and over. The naive strategy to do something like:

    howl.off('end').on('end', function () { ... })

However, that will end up removing all other event listeners, which may not be desirable. This update ensures that this will proceed cleanly. Additionally, you may only want something to happen once (e.g. if you keep changing the succession state).

My other strategy for dealing with the x.off.on situation is to create a function called "ion" for "idempotent on", but I don't think anyone else will remember that. ;)

The function is justified by the fact that there's a small trick to writing it that shouldn't be necessary each time you need to do this, and I think it's a common enough problem that others might be interested. For instance, jQuery has a 'one' function as well (though that's a slightly different domain).

Thank you for making such a lovely library. :+1: 