### PR TITLE
_clearEndTimer accidentally clears first timer in array

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -1060,7 +1060,7 @@
      */
     _clearEndTimer: function(soundId) {
       var self = this,
-        index = 0;
+        index = -1;
 
       // loop through the timers to find the one associated with this sound
       for (var i=0; i<self._onendTimer.length; i++) {


### PR DESCRIPTION
Why?
When the soundId passed to _clearEndTimer() does not exist, the first timer in the _onendTimer array will be cleared, instead it should do nothing. This situation will occur when playing several overlapping instances of the same sound, the "end" event will not fire for all instances.

How?
Start index at -1 instead of 0, timer will not exist if not found in the loop.