### PR TITLE
.off - Do not compare functions by string

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -1136,13 +1136,12 @@
      */
     off: function(event, fn) {
       var self = this,
-        events = self['_on' + event],
-        fnString = fn ? fn.toString() : null;
+        events = self['_on' + event];
 
-      if (fnString) {
+      if (fn) {
         // loop through functions in the event for comparison
         for (var i=0; i<events.length; i++) {
-          if (fnString === events[i].toString()) {
+          if (fn === events[i]) {
             events.splice(i, 1);
             break;
           }


### PR DESCRIPTION
Why?
Comparing functions by string means that where different instances of the same function are added as a listener to the same Howl, attempting to remove one instance of the function could infact remove a different instance...

**Fiddle: http://jsfiddle.net/vbLja5g6/1/**

How?
Compare functions not strings