### PR TITLE
Fix amd define to not be opinionated on pkg name.

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -1807,7 +1807,7 @@
 
   // Add support for AMD (Asynchronous Module Definition) libraries such as require.js.
   if (typeof define === 'function' && define.amd) {
-    define('howler', function() {
+    define([], function() {
       return {
         Howler: Howler,
         Howl: Howl


### PR DESCRIPTION
The `define()` call used deprecated syntax with hard-coded package name - it is discouraged and will cause trouble when optimizing dependencies in multi-library projects.