### PR TITLE
ogg/vorbis audio only file can (should?) use the .oga extension

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -191,6 +191,7 @@
         mpeg: !!mpegTest,
         opus: !!audioTest.canPlayType('audio/ogg; codecs="opus"').replace(/^no$/, ''),
         ogg: !!audioTest.canPlayType('audio/ogg; codecs="vorbis"').replace(/^no$/, ''),
+        oga: !!audioTest.canPlayType('audio/ogg; codecs="vorbis"').replace(/^no$/, ''),
         wav: !!audioTest.canPlayType('audio/wav; codecs="1"').replace(/^no$/, ''),
         aac: !!audioTest.canPlayType('audio/aac;').replace(/^no$/, ''),
         m4a: !!(audioTest.canPlayType('audio/x-m4a;') || audioTest.canPlayType('audio/m4a;') || audioTest.canPlayType('audio/aac;')).replace(/^no$/, ''),


### PR DESCRIPTION
See "the default .oga file extension" in [RFC 5334](http://www.ietf.org/rfc/rfc5334.txt)