### PR TITLE
Add a string validation check for sources

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -438,6 +438,12 @@
       // Loop through the sources and pick the first one that is compatible.
       for (var i=0; i<self._src.length; i++) {
         var ext, str;
+        
+        // Make sure the source is actually a string
+        if (typeof str !== 'string') {
+          self._emit('loaderror', null, 'Non-string found in selected audio sources - ignoring.');
+          continue;
+        }
 
         if (self._format && self._format[i]) {
           // If an extension was specified, use that instead.


### PR DESCRIPTION
I was caught out by this because AngularJS can wrap strings in TrustedValueHolderTypes which it uses for templates when using external sources.

This would also need to be done on v1.x