### PR TITLE
Bug fix - queue gets stuck when two plays are called

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -553,6 +553,14 @@
 
       // Don't play the sound if an id was passed and it is already playing.
       if (id && !sound._paused) {
+
+        // Trigger the play event, in order to keep iterating through queue
+        if (!args[1]) {
+          setTimeout(function() {
+            self._emit('play', sound._id);
+          }, 0);
+        }
+
         return sound._id;
       }
 


### PR DESCRIPTION
When play() is called twice consecutively before audio loads, queue will not advance.