### PR TITLE
Fix IE ability to listen to <audio> ended event

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -512,7 +512,11 @@
             node.currentTime = pos;
             node.muted = Howler._muted || node.muted;
             node.volume = self._volume * Howler.volume();
-            setTimeout(function() { node.play(); }, 0);
+            setTimeout(function() {
+              node.play();
+              // this line added to fix IE ability to hear native ended event. (ryanore)
+              self._clearEndTimer(soundId); 
+            }, 0);
           } else {
             self._clearEndTimer(soundId);
 


### PR DESCRIPTION
We are listening to the native <audio> 'ended' event for IE because it lags when listening to the Howler provided 'end' event.  

However, because howler.js has things working within self-invoked closures, I can't access it from outside in order to clear timers.

I think it may actually be an oversight in the howler.js lib anyway and this change might be suited for a PR in the goldfire repo.  I will follow up on that.
