### PR TITLE
Fix unpausing of a multi-node looping sound

### DIFF
--- a/howler.js
+++ b/howler.js
@@ -436,7 +436,7 @@
         node._sprite = sprite;
 
         // determine where to start playing from
-        var pos = (node._pos > 0) ? node._pos : self._sprite[sprite][0] / 1000;
+        var pos = (node._pos > 0) ? node._pos % (self._sprite[sprite][1] / 1000) : self._sprite[sprite][0] / 1000;
 
         // determine how long to play for
         var duration = 0;
@@ -497,7 +497,7 @@
           node.id = soundId;
           node.paused = false;
           refreshBuffer(self, [loop, loopStart, loopEnd], soundId);
-          self._playStart = ctx.currentTime;
+          node._playStart = ctx.currentTime;
           node.gain.value = self._volume;
 
           if (typeof node.bufferSource.start === 'undefined') {
@@ -800,7 +800,7 @@
 
           return self;
         } else {
-          return self._webAudio ? activeNode._pos + (ctx.currentTime - self._playStart) : activeNode.currentTime;
+          return self._webAudio ? activeNode._pos + (ctx.currentTime - activeNode._playStart) : activeNode.currentTime;
         }
       } else if (pos >= 0) {
         return self;


### PR DESCRIPTION
This seams to fix 2 issues that I've found for:
1. A looping sound, when played at least one loop, then paused and then played back again - it will have the position calculated to be greater then the sprite duration. Resulting in a negative timeout value and failing to resume the play.
2. Also a looping sound but with multiple nodes started at the different time, when paused and played back again - all the nodes will get the same resume position. Instead of approximately the same offsets as they had when they were started.
