### PR TITLE
'playing' method behavior change

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -1288,7 +1288,7 @@
     },
 
     /**
-     * Check if a specific sound is currently playing or not (if id is provided), or check if at least one of the sounds in the group is playing or not
+     * Check if a specific sound is currently playing or not (if id is provided), or check if at least one of the sounds in the group is playing or not.
      * @param  {Number}  id The sound id to check. If none is passed, the whole sound group is checked.
      * @return {Boolean} True if playing and false if not.
      */

--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -1288,15 +1288,29 @@
     },
 
     /**
-     * Check if a specific sound is currently playing or not.
-     * @param  {Number} id The sound id to check. If none is passed, first sound is used.
-     * @return {Boolean}    True if playing and false if not.
+     * Check if a specific sound is currently playing or not (if id is provided), or check if at least one of the sounds in the group is playing or not
+     * @param  {Number}  id The sound id to check. If none is passed, the whole sound group is checked.
+     * @return {Boolean} True if playing and false if not.
      */
     playing: function(id) {
       var self = this;
-      var sound = self._soundById(id) || self._sounds[0];
 
-      return sound ? !sound._paused : false;
+      if (typeof id === 'number') {
+        var sound = self._soundById(id);
+        if (sound) {
+          return !sound._paused;
+        }
+      }
+
+      var sounds = self._sounds;
+      var len = sounds.length;
+      for (var i=0; i<len; i++) {
+        if (!sounds[i]._paused) {
+          return true;
+        }
+      }
+
+      return false;
     },
 
     /**


### PR DESCRIPTION
The current 'playing' method behavior is a bit misleading, since it will only check the first instance of the sound group if an id is not passed. Checking the whole sound group would be far more useful, imho. My proposed change is when the user calls the method without passing an id, the whole group will be loop-checked. If at least one of the sound instances is still playing, the method will return true.