### PR TITLE
Will not attempt to play a sprite id if it does not exist.

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -555,6 +555,9 @@
       if (typeof sprite === 'number') {
         id = sprite;
         sprite = null;
+      } else if ( typeof sprite === 'string' && self._state === 'loaded' && !self._sprite[sprite] ) {
+        // If the sound to play within the sprite doesn't exist, do nothing
+        return null;
       } else if (typeof sprite === 'undefined') {
         // Use the default sound sprite (plays the full audio length).
         sprite = '__default';


### PR DESCRIPTION
Solves errors that would otherwise be thrown up later in the code that assumes that the sprite name does exist.

```
var seek = sound._seek > 0 ? sound._seek : self._sprite[sprite][0] / 1000;
var duration = ((self._sprite[sprite][0] + self._sprite[sprite][1]) / 1000) - seek;
var timeout = (duration * 1000) / Math.abs(sound._rate);
```