### PR TITLE
fix looping sound not playing on chrome

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -652,7 +652,7 @@
           if (typeof node.bufferSource.start === 'undefined') {
             sound._loop ? node.bufferSource.noteGrainOn(0, seek, 86400) : node.bufferSource.noteGrainOn(0, seek, duration);
           } else {
-            sound._loop ? node.bufferSource.start(0, seek, 86400) : node.bufferSource.start(0, seek, duration);
+            sound._loop ? node.bufferSource.start(0, seek) : node.bufferSource.start(0, seek, duration);
           }
 
           // Start a new timer if none is present.


### PR DESCRIPTION
Fixes that in chrome latest stable version (51.0.2704.106), (at least) using windows 7, a sound with loop = true does not play, instead all you hear is a beep