### PR TITLE
Fix sprite duration calculation, makes timeout and 'end' fire correctly

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -624,7 +624,7 @@
 
       // Determine how long to play for and where to start playing.
       var seek = sound._seek > 0 ? sound._seek : self._sprite[sprite][0] / 1000;
-      var duration = ((self._sprite[sprite][0] + self._sprite[sprite][1]) / 1000) - seek;
+      var duration = (self._sprite[sprite][1] / 1000) - seek;
       var timeout = (duration * 1000) / Math.abs(sound._rate);
 
       // Update the parameters of the sound


### PR DESCRIPTION
The duration calculation when using sprites were off as the start time was added on to it, making 'end' event fire (sometimes much) later than it should.