### PR TITLE
reset audio context noAudio to false when unload

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -1442,7 +1442,7 @@
       }
 
       // Clear global errors
-      Howler.noAudio = false
+      Howler.noAudio = false;
 
       // Clear out `self`.
       self._state = 'unloaded';

--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -1441,6 +1441,9 @@
         delete cache[self._src];
       }
 
+      // Clear global errors
+      Howler.noAudio = false
+
       // Clear out `self`.
       self._state = 'unloaded';
       self._sounds = [];


### PR DESCRIPTION
Our case is using multiple audios on web page.
I unload a Howl object when the audio load failed. I found that noAudio not reset when unload method invoked. So I set global `Howler.noAudio`to false, otherwise others created audio object cannot play.