### PR TITLE
Fix IE11 issue in enhanced security mode on TerminalServer.

### DIFF
--- a/dist/howler.js
+++ b/dist/howler.js
@@ -200,7 +200,12 @@
      */
     _setupCodecs: function() {
       var self = this || Howler;
-      var audioTest = (typeof Audio !== 'undefined') ? new Audio() : null;
+      try {
+        var audioTest = (typeof Audio !== 'undefined') ? new Audio() : null;
+      }
+      catch(e) {
+        return self;
+      }
 
       if (!audioTest || typeof audioTest.canPlayType !== 'function') {
         return self;


### PR DESCRIPTION
The howler initialization fails and breaks the whole site`s script, in IE11 on Windows Server 2008 R2 in enhanced security mode (error message: "not implemented").
To reproduce the problem, it is enough to open a website _including_ the howler script; even if it is not used / called anywhere.
I was not able to check the implementation by using any detection method:
- `!!document.createElement('audio').canPlayType` equals true (recommended [here](http://diveintohtml5.info/everything.html#audio)),
- `typeof Audio` equals `function`

The engine then crashes on executing `new Audio()`.
