### PR TITLE
Confirm Howler.ctx exists before destroying in unload()

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -155,7 +155,7 @@
       }
 
       // Create a new AudioContext to make sure it is fully reset.
-      if (self.usingWebAudio && typeof self.ctx.close !== 'undefined') {
+      if (self.usingWebAudio && self.ctx && typeof self.ctx.close !== 'undefined') {
         self.ctx.close();
         self.ctx = null;
         setupAudioContext();


### PR DESCRIPTION
This ensures that `Howler.unload()` can be called at any time without throwing an error - which is less of a problem than I first thought, but nonetheless caught me out earlier.

Addresses: #645 
