### PR TITLE
Ensure self.ctx exists before checking self.ctx.close

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -155,7 +155,7 @@
       }
 
       // Create a new AudioContext to make sure it is fully reset.
-      if (self.usingWebAudio && typeof self.ctx.close !== 'undefined') {
+      if (self.usingWebAudio && self.ctx && typeof self.ctx.close !== 'undefined') {
         self.ctx.close();
         self.ctx = null;
         setupAudioContext();


### PR DESCRIPTION
Calling Howler.unload() can give the error "Can't read property 'close' of null", especially if having several Howl instances.