### PR TITLE
Fix a bug with AudioBufferSourceNode

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -623,8 +623,8 @@
       }
 
       // Determine how long to play for and where to start playing.
-      var seek = sound._seek > 0 ? sound._seek : self._sprite[sprite][0] / 1000;
-      var duration = ((self._sprite[sprite][0] + self._sprite[sprite][1]) / 1000) - seek;
+      var seek = Math.max(0, sound._seek > 0 ? sound._seek : self._sprite[sprite][0] / 1000);
+      var duration = Math.max(0, ((self._sprite[sprite][0] + self._sprite[sprite][1]) / 1000) - seek);
       var timeout = (duration * 1000) / Math.abs(sound._rate);
 
       // Update the parameters of the sound


### PR DESCRIPTION
https://github.com/goldfire/howler.js/issues/226

It seems as though AudioBufferSourceNode can get caught in cases where the seek and duration are negative 
"Failed to execute 'start' on 'AudioBufferSourceNode': The duration provided (-0.17) is less than the minimum bound (0)"

We can protect this by defaulting to 0 when we seek or set a duration below 0.