### PR TITLE
Fixing stop all sounds bug when a bufferSource is null.

### DIFF
--- a/dist/howler.js
+++ b/dist/howler.js
@@ -815,7 +815,7 @@
             if (self._webAudio) {
               // make sure the sound has been created
               if (!sound._node.bufferSource) {
-                return self;
+                continue;
               }
 
               if (typeof sound._node.bufferSource.stop === 'undefined') {
@@ -890,7 +890,7 @@
                   self._emit('stop', sound._id);
                 }
 
-                return self;
+                continue;
               }
 
               if (typeof sound._node.bufferSource.stop === 'undefined') {

--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -815,7 +815,7 @@
             if (self._webAudio) {
               // make sure the sound has been created
               if (!sound._node.bufferSource) {
-                return self;
+                continue;
               }
 
               if (typeof sound._node.bufferSource.stop === 'undefined') {
@@ -890,7 +890,7 @@
                   self._emit('stop', sound._id);
                 }
 
-                return self;
+                continue;
               }
 
               if (typeof sound._node.bufferSource.stop === 'undefined') {


### PR DESCRIPTION
Pausing and stopping all don't work if the for loops return out early. I think `continue;` is more appropriate.