### PR TITLE
Update howler.core.js

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -1468,7 +1468,6 @@
         // Stop the sound if it is currently playing.
         if (!sounds[i]._paused) {
           self.stop(sounds[i]._id);
-          self._emit('end', sounds[i]._id);
         }
 
         // Remove the source or disconnect.


### PR DESCRIPTION
Sometimes, users want to change the playlist, so i unload the howler instance and create a new one, but when i unload the instance, the '_onend' event listener will trigger every time.

In my case, the next method will affect the playlist too, so it bother me a lot. I think when people unload the instance, they do not want affect anything, so why emit the 'end' event ?

If you have some better idea, please let me know, thank you.