### PR TITLE
Remove setTimeout() call that caused loss of call stack

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -736,18 +736,16 @@
           node.volume = sound._volume * Howler.volume();
           node.playbackRate = sound._rate;
 
-          setTimeout(function() {
-            node.play();
+          node.play();
 
-            // Setup the new end timer.
-            if (timeout !== Infinity) {
-              self._endTimers[sound._id] = setTimeout(self._ended.bind(self, sound), timeout);
-            }
+          // Setup the new end timer.
+          if (timeout !== Infinity) {
+            self._endTimers[sound._id] = setTimeout(self._ended.bind(self, sound), timeout);
+          }
 
-            if (!internal) {
-              self._emit('play', sound._id);
-            }
-          }, 0);
+          if (!internal) {
+            self._emit('play', sound._id);
+          }
         };
 
         // Play immediately if ready, or wait for the 'canplaythrough'e vent.


### PR DESCRIPTION
See issue: #609 

On mobile, the play event needs to be triggered by a user gesture. By setting a timeout the call
stack containing the user tap gesture is lost. Since this was added way back to support something in Firefox 13 it could most likely be removed without negative impact.