### PR TITLE
Check sound status before playHtml5()

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -756,6 +756,19 @@
           playHtml5();
         } else {
           var listener = function() {
+              
+              //It's possible stop or pause has been called in the meantime.
+              //Check this for looped sounds to avoid looping forever.
+               if (self._loop){
+                for(var i = 0, len = self._queue.length; i < len; i++){
+                    var eventType = self._queue[i].event;
+                    if(eventType === 'stop' || eventType === 'pause'){
+                        self.loop(false);
+                        break;
+                    }
+                }
+            }
+            
             // Begin playback.
             playHtml5();
 

--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -2162,7 +2162,7 @@
     // Create and expose the master GainNode when using Web Audio (useful for plugins or advanced usage).
     if (Howler.usingWebAudio) {
       Howler.masterGain = (typeof Howler.ctx.createGain === 'undefined') ? Howler.ctx.createGainNode() : Howler.ctx.createGain();
-      Howler.masterGain.gain.value = 1;
+      Howler.masterGain.gain.value = Howler._muted ? 0 : 1;
       Howler.masterGain.connect(Howler.ctx.destination);
     }
 


### PR DESCRIPTION
Playing a looped sound in IE11 (HTML audio) and stopping it again either, immediately or after a short delay, causes the sound to loop indefinitely.
I found the minimum time to safely play and stop a looping sound was about 800ms - anything less and the sound would result in the bug.
This is due to the readyState not being 4 (canPlayThrough) initially. After the readyState callback, no check is made whether the sound has been stopped in the meantime before playHtml5() is called.

I found playing the sound at least once (loop false) rather than just having silence was more desirable.