### PR TITLE
510 + 606 + 592- IE bugs. Unsupported mime issues, IE not supporting …

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -1479,7 +1479,6 @@
         // Remove the source or disconnect.
         if (!self._webAudio) {
           // Set the source to 0-second silence to stop any downloading.
-          sounds[i]._node.src = 'data:audio/wav;base64,UklGRigAAABXQVZFZm10IBIAAAABAAEARKwAAIhYAQACABAAAABkYXRhAgAAAAEA';
 
           // Remove any event listeners.
           sounds[i]._node.removeEventListener('error', sounds[i]._errorFn, false);
@@ -1653,6 +1652,14 @@
      */
     _ended: function(sound) {
       var self = this;
+      // If we are using IE and there was network latency we may be clipping
+      // audio before it completes playing. Lets check the node to make sure it
+      // believes it has completed, before ending the playback.
+      if (!self._webAudio && !self._node.ended) {
+        setTimeout(self._ended.bind(self, sound), 100);
+        return self;
+      }
+
       var sprite = sound._sprite;
 
       // Should this sound loop?
@@ -1980,7 +1987,7 @@
       self._parent._emit('loaderror', self._id, self._node.error ? self._node.error.code : 0);
 
       // Clear the event listener.
-      self._node.removeEventListener('error', self._errorListener, false);
+      self._node.removeEventListener('error', self._errorFn, false);
     },
 
     /**


### PR DESCRIPTION
…base64 audio nor Wav files, Audio clipping before ending


## Unsupported mime issues & Base 64 Issues
Eventually once all the sound nodes are used up for a howl and it starts to recycle you will see a 
`Audio/Video: Unknown Mime type` [Issue-510](https://github.com/goldfire/howler.js/issues/510)
https://connect.microsoft.com/IE/feedbackdetail/view/833467/internet-explorer-11-cannot-play-audio-file-with-data-in-base64
http://hodentekhelp.blogspot.com/2014/03/how-to-code-audio-file-to-run-in-html5.html

## Audio Clipping
We have seen that in IE when we are dealing with HTML nodes, if there is a delay in the network this can lead to audio getting clipped. The audio maybe chunked and return a duration value that howler is using to clip the sound. Instead for the audio nodes we should watch the native 'ended' event to know that the audio has stopped playing

## Dangling Event listener
IE has a set limit to the number of audio nodes that can exist at a given time. In the current library it seems that this issue still exists, that nodes are not properly being removed. It seems as though the error listener that was being removed in the `_errorListener` was the wrong one.  We listen for `_errorFn` for audio error events.
`self._errorFn = self._errorListener.bind(self);`  

## Related Issues
 [Issue-510](https://github.com/goldfire/howler.js/issues/510)
 [Issue-606](https://github.com/goldfire/howler.js/issues/606) May need additional logic for sprite maps
 [Issue-592](https://github.com/goldfire/howler.js/issues/592)
