### PR TITLE
Fix for WebAudio context not being unlocked on Android Chrome >= 55.

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -316,7 +316,9 @@
         }
 
         // Calling resume() on a stack initiated by user gesture is what actually unlocks the audio on Android Chrome >= 55.
-        self.ctx.resume();
+        if (typeof self.ctx.resume === 'function') {
+          self.ctx.resume();
+        }
 
         // Setup a timeout to check that we are unlocked on the next event loop.
         source.onended = function() {

--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -315,6 +315,9 @@
           source.start(0);
         }
 
+        // Calling resume() on a stack initiated by user gesture is what actually unlocks the audio on Android Chrome >= 55.
+        self.ctx.resume();
+
         // Setup a timeout to check that we are unlocked on the next event loop.
         source.onended = function() {
           source.disconnect(0);


### PR DESCRIPTION
I've encountered situations in which audio won't play on latest Android Chrome.
Recent Chrome changes cause AudioContext() to stay locked in suspended state, unless `resume()` is explicitly called from a stack initiated by user gesture.
This commit fixes it.