### PR TITLE
fix: license should be a valid SPDX license expression

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,10 +22,7 @@
     "url": "git://github.com/goldfire/howler.js.git"
   },
   "main": "dist/howler.js",
-  "license": {
-    "type": "MIT",
-    "url": "https://raw.githubusercontent.com/goldfire/howler.js/master/LICENSE.md"
-  },
+  "license": "MIT",
   "moduleType": [
     "amd",
     "globals",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,7 @@
   },
   "main": "dist/howler.js",
   "version": "2.0.3",
-  "license": {
-    "type": "MIT",
-    "url": "https://raw.githubusercontent.com/goldfire/howler.js/master/LICENSE.md"
-  },
+  "license": "MIT",
   "files": [
     "src",
     "dist/howler.js",


### PR DESCRIPTION
when `npm install` on a fork, npm complains that license filed in package.json is not valid.

See https://docs.npmjs.com/files/package.json#license for valid `license` metadata.