### PR TITLE
Fix Android Chrome no sound issue

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -424,7 +424,8 @@
         self._resumeAfterSuspend = true;
       } else if (self.state === 'resuming') {
         // in Android Chrome, state will remain resuming because self.ctx.resume will throw an warn 
-        // and it will never go next, so we need to cover also the case where state is resuming.
+        // and it will never go next, so we need to cover also the case where state is resuming and 
+        // try again to resume after a user gesture
           resumeFunction();
       }
 


### PR DESCRIPTION
Issues occurs in the following conditions:

Game is open in Android device
Chrome version >= 55
Game is open in iFrame
Game domain and iFrame parent domain are not the same

Sound state will remain 'resuming' and it will never try again to resume after a user gesture.