### PR TITLE
Duplicate playWebAudio fix

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -1548,6 +1548,16 @@
       var self = this;
       var events = self['_on' + event];
 
+      if(once){
+        for (var i=0; i < events.length; i++) {
+          var storedEvent = events[i];
+          if(storedEvent.once && (''+storedEvent.fn == ''+fn)){
+            //event already stored
+            return;
+          }
+        }
+      }
+
       if (typeof fn === 'function') {
         events.push(once ? {id: id, fn: fn, once: once} : {id: id, fn: fn});
       }


### PR DESCRIPTION
In Firefox playWebAudio is called twice on same sound due to duplicate self.once() calls to resume after loading. This fix stops duplicate 'once' events from being stored.

Specifically the problem arose when 
`self.once(event, playWebAudio, isRunning ? sound._id : null);`
inside the play function was called twice while a sound was still loading but could also be duplicated in some instances by letting the browser rest for a time between playing sounds.

The bug was introduced with this commit: https://github.com/goldfire/howler.js/commit/3abbeed9d03be7d300bf87918704945be1b7c055

Sometimes the sounds would be played far enough apart that it would sound like the same track played twice, but most times would be played at the same time so a call to stop() would seem not to work. This thread shows other's dealing with the same problem. http://community.openfl.org/t/html-sound-woes-after-howler-replaces-soundjs/8839/14
