### PR TITLE
Fix error when seeking with unloaded state

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -1355,7 +1355,9 @@
         if (index >= 0) {
           id = parseInt(args[0], 10);
         } else {
-          id = self._sounds[0]._id;
+          if (self._sounds.length > 0) {
+            id = self._sounds[0]._id;
+          }
           seek = parseFloat(args[0]);
         }
       } else if (args.length === 2) {


### PR DESCRIPTION
This is a fix for #796 

We could also check the length of `ids` but I think the intention is more clear by using `self._sounds`.

If the state is `unloaded` there will be no `_sounds` so the `id` will be left as `undefined` and the function will bail on line 1370:

```js
1368:      // If there is no ID, bail out.
1369:      if (typeof id === 'undefined') {
1370:        return self;
1371:      }
```