### PR TITLE
Add xhr timeout behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ The rate of playback. 0.5 to 4.0, with 1.0 being normal speed.
 The size of the inactive sounds pool. Once sounds are stopped or finish playing, they are marked as ended and ready for cleanup. We keep a pool of these to recycle for improved performance. Generally this doesn't need to be changed. It is important to keep in mind that when a sound is paused, it won't be removed from the pool and will still be considered active so that it can be resumed later.
 #### format `Array` `[]`
 howler.js automatically detects your file format from the extension, but you may also specify a format in situations where extraction won't work (such as with a SoundCloud stream).
+#### timeout `Number` `0`
+The number of milliseconds the download request can take before automatically being terminated. The default value is 0, which means there is no timeout.
 #### onload `Function`
 Fires when the sound is loaded.
 #### onloaderror `Function`

--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -473,6 +473,7 @@
       self._sprite = o.sprite || {};
       self._src = (typeof o.src !== 'string') ? o.src : [o.src];
       self._volume = o.volume !== undefined ? o.volume : 1;
+      self._timeout = o.timeout || 0;
 
       // Setup all other default properties.
       self._duration = 0;
@@ -2072,6 +2073,10 @@
       var xhr = new XMLHttpRequest();
       xhr.open('GET', url, true);
       xhr.responseType = 'arraybuffer';
+      xhr.timeout = self._timeout;
+      xhr.ontimeout = function(){
+        obj.on('loaderror', new Error('File load timed out.'));
+      }
       xhr.onload = function() {
         // Make sure we get a successful response back.
         var code = (xhr.status + '')[0];


### PR DESCRIPTION
Adding a timeout property to audio requests. 

I'm working on a project now where it makes more sense to fall back to TTS if it's taking longer than say, 5-10 seconds.

I'm actually not 100% clear on the behavior of the default value (0), I'm just going by what's on the [Mozilla docs](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/timeout).