### PR TITLE
Add touchstart to enable mobile audio when swiping too

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -333,11 +333,13 @@
 
           // Remove the touch start listener.
           document.removeEventListener('touchend', unlock, true);
+          document.removeEventListener('touchstart', unlock, true);
         };
       };
 
       // Setup a touch start listener to attempt an unlock in.
       document.addEventListener('touchend', unlock, true);
+      document.addEventListener('touchstart', unlock, true);
 
       return self;
     },


### PR DESCRIPTION
On iOS, if you swipe, for some reason `touchend` doesn't get triggered. We're building a WebGL game where you needed to perform a swipe movement and sound was only enabled when you actually tapped. Using `touchstart` seems to fix it. I think it is safe to keep two listeners.

When is the next release planned?