### PR TITLE
Fix support for Firefox (without double-play)

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -2201,7 +2201,7 @@
       Howler.usingWebAudio = false;
     }
     
-    Howler._initSuspended = (Howler.ctx.state != null && Howler.ctx.state === 'suspended');
+    Howler._initSuspended = (typeof Howler.ctx !== 'undefined' && Howler.ctx && Howler.ctx.state != null && Howler.ctx.state === 'suspended');
 
     // Check if a webview is being used on iOS8 or earlier (rather than the browser).
     // If it is, disable Web Audio as it causes crashing.

--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -183,7 +183,7 @@
     _setup: function() {
       var self = this || Howler;
 
-      if (self._initSuspended && self.ctx && self.ctx != 'suspended') {
+      if (self._initSuspended && self.ctx && self.ctx.state != 'suspended') {
         self._initSuspended = false;
       }
       

--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -183,8 +183,12 @@
     _setup: function() {
       var self = this || Howler;
 
+      if (self._initSuspended && self.ctx && self.ctx != 'suspended') {
+        self._initSuspended = false;
+      }
+      
       // Keeps track of the suspend/resume state of the AudioContext.
-      self.state = self.ctx ? self.ctx.state || 'running' : 'running';
+      self.state = (self.ctx && !self._initSuspended) ? self.ctx.state || 'running' : 'running';
 
       // Automatically begin the 30-second suspend process
       self._autoSuspend();
@@ -2196,6 +2200,8 @@
     } catch(e) {
       Howler.usingWebAudio = false;
     }
+    
+    Howler._initSuspended = (Howler.ctx.state != null && Howler.ctx.state === 'suspended');
 
     // Check if a webview is being used on iOS8 or earlier (rather than the browser).
     // If it is, disable Web Audio as it causes crashing.


### PR DESCRIPTION
This is a workaround for an issue in howler.js which causes sounds to be played twice on Firefox. This pull request is a workaround for the standard case, but there is a deeper issue you may want to look into.

Our use-case looks similar to this code:

```js
var howl = new Howl ({ src: [ path ], preload: false });
howl.on ("load", function () {
	var id = howl.play ();
	howl.seek (1000, id);
});
```

On Chrome or Opera, a new `AudioContext` has a `state` of "running". Firefox initializes with a `state` of "suspended", though `ctx.resume()` is not required to begin playback. The workaround in this pull request is to treat this initial "suspended" state as if it is "running", as in practice, it does work the same way. This should not damage support for true suspend/resume events in the future.

The bug we see is that calling the above code causes Firefox to play our sound once from the start, and once from the position we requested. The true cause is some combination of calling `playWebAudio` with a delay internally. Somewhere in the code, it assumes that the sound is paused and needs to be resumed, and thus it ends up playing twice.

A workaround is needed to provide proper support in Firefox and Firefox Quantum, but long-term it may be necessary to detect the "is waiting to be played" status, or prevent the delayed `playWebAudio` from calling if another method forced the sound to play.

If I may make a feature request, it would really help us to have official support for setting the volume, start position or other properties when we call `play`, without baking them into our sound permanently, such as:

```js
howl.play ({ volume: 0.5, position: 1000 });
```

We play sounds from different beginning volume and positions, and do not know during our preload phase what the user will want to use. This is implemented behind an open-source Flash library

Thank you :smile: