### PR TITLE
Fix audio promise for Safari 11

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -776,6 +776,9 @@
               play.then(function () {
                 self._playLock = false;
                 self._loadQueue();
+              }, function () {
+                self._playLock = false;
+                self._loadQueue();
               });
             }
 


### PR DESCRIPTION
HIGH PRIORITY

Strange but working fix for Safari 11.
Related to issue #840.