### PR TITLE
Fixed checking of the option parameter (Optoins -> src) for type matc…

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -442,7 +442,7 @@
     var self = this;
 
     // Throw an error if no source is provided.
-    if (!o.src || o.src.length === 0) {
+    if (!o.src || o.src.length === 0 || !(o.src instanceof Array)) {
       console.error('An array of source files must be passed with any new Howl.');
       return;
     }


### PR DESCRIPTION
Fix [Options->src] checking, because in the documentation src is array type
```
src Array [] required
```
