### PR TITLE
Handle audio context state of interrupted

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -406,7 +406,7 @@
       if (self.state === 'running' && self._suspendTimer) {
         clearTimeout(self._suspendTimer);
         self._suspendTimer = null;
-      } else if (self.state === 'suspended') {
+      } else if (self.state === 'suspended' || self.state === 'interrupted') {
         self.ctx.resume().then(function() {
           self.state = 'running';
 


### PR DESCRIPTION
Using Chrome on iOS 11, if the screen is turned off the web audio context goes into an interrupted state. Using Howler, it never resumes and no audio plays after turning the screen back on. This updates the autoResume to also handle the interrupted state.