### PR TITLE
Add ability to subscribe to progress event when loading a URL

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -491,6 +491,7 @@
       self._onload = o.onload ? [{fn: o.onload}] : [];
       self._onloaderror = o.onloaderror ? [{fn: o.onloaderror}] : [];
       self._onplayerror = o.onplayerror ? [{fn: o.onplayerror}] : [];
+      self._onloadprogress = o.onloadprogress ? [{fn: o.onloadprogress}] : [];
       self._onpause = o.onpause ? [{fn: o.onpause}] : [];
       self._onplay = o.onplay ? [{fn: o.onplay}] : [];
       self._onstop = o.onstop ? [{fn: o.onstop}] : [];
@@ -2177,6 +2178,9 @@
           delete cache[url];
           self.load();
         }
+      };
+      xhr.onprogress = function(event) {
+        self._emit('loadprogress', event)
       };
       safeXhrSend(xhr);
     }


### PR DESCRIPTION
This is a small change that adds an additional emitted event: `loadprogress` that sends standard [XHR `ProgressEvent`s](https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent).

Will happily update docs/etc. if you're interested in merging this change.