### PR TITLE
Fix: error happen in isomorphic dev environment (ex: react.js)

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -2243,8 +2243,8 @@
     try {
       if (typeof AudioContext !== 'undefined') {
         Howler.ctx = new AudioContext();
-      } else if (typeof webkitAudioContext !== 'undefined') {
-        Howler.ctx = new webkitAudioContext();
+      } else if (typeof window.webkitAudioContext !== 'undefined') {
+        Howler.ctx = new window.webkitAudioContext();
       } else {
         Howler.usingWebAudio = false;
       }
@@ -2276,8 +2276,8 @@
   };
 
   // Add support for AMD (Asynchronous Module Definition) libraries such as require.js.
-  if (typeof define === 'function' && define.amd) {
-    define([], function() {
+  if (window.define && typeof window.define === 'function' && window.define.amd) {
+    window.define([], function() {
       return {
         Howler: Howler,
         Howl: Howl

--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -2241,7 +2241,7 @@
   var setupAudioContext = function() {
     // Check if we are using Web Audio and setup the AudioContext if we are.
     try {
-      if (typeof AudioContext !== 'undefined') {
+      if (typeof window.AudioContext !== 'undefined') {
         Howler.ctx = new AudioContext();
       } else if (typeof window.webkitAudioContext !== 'undefined') {
         Howler.ctx = new window.webkitAudioContext();


### PR DESCRIPTION
Fix: error happen in isomorphic dev environment (ex: react.js), when  bot `webkitAudioContext` and `define` is not support in Node.js env