### PR TITLE
Fix for issue #986 handling decodeAudioData events in latest chrome

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -2202,25 +2202,25 @@
    * @param  {ArrayBuffer} arraybuffer The audio data.
    * @param  {Howl}        self
    */
-	var decodeAudioData = function(arraybuffer, self) {
+  var decodeAudioData = function(arraybuffer, self) {
     var handle = function(buffer) {
       if (buffer && self._sounds.length > 0) {
-		    cache[self._src] = buffer;
-		    loadSound(self, buffer);
-		  } else {
+        cache[self._src] = buffer;
+        loadSound(self, buffer);
+      } else {
         onError();
       }
-	  };
-	  var onError = function() {
-		  self._emit('loaderror', null, 'Decoding audio data failed.');
-	  };
-	  // Decode the buffer into an audio source.
-	  if(Howler.ctx.decodeAudioData.length === 1) {
-	    Howler.ctx.decodeAudioData(arraybuffer).then(handle).catch(onError);
-	  } else {
-	    Howler.ctx.decodeAudioData(arraybuffer, handle, onError);
-	  }
-	}
+    };
+    var onError = function() {
+      self._emit('loaderror', null, 'Decoding audio data failed.');
+    };
+    // Decode the buffer into an audio source.
+    if(Howler.ctx.decodeAudioData.length === 1) {
+      Howler.ctx.decodeAudioData(arraybuffer).then(handle).catch(onError);
+    } else {
+      Howler.ctx.decodeAudioData(arraybuffer, handle, onError);
+    }
+  }
 
   /**
    * Sound is now loaded, so finish setting everything up and fire the loaded event.

--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -2202,17 +2202,25 @@
    * @param  {ArrayBuffer} arraybuffer The audio data.
    * @param  {Howl}        self
    */
-  var decodeAudioData = function(arraybuffer, self) {
-    // Decode the buffer into an audio source.
-    Howler.ctx.decodeAudioData(arraybuffer, function(buffer) {
+	var decodeAudioData = function(arraybuffer, self) {
+    var handle = function(buffer) {
       if (buffer && self._sounds.length > 0) {
-        cache[self._src] = buffer;
-        loadSound(self, buffer);
+		    cache[self._src] = buffer;
+		    loadSound(self, buffer);
+		  } else {
+        onError();
       }
-    }, function() {
-      self._emit('loaderror', null, 'Decoding audio data failed.');
-    });
-  };
+	  };
+	  var onError = function() {
+		  self._emit('loaderror', null, 'Decoding audio data failed.');
+	  };
+	  // Decode the buffer into an audio source.
+	  if(Howler.ctx.decodeAudioData.length === 1) {
+	    Howler.ctx.decodeAudioData(arraybuffer).then(handle).catch(onError);
+	  } else {
+	    Howler.ctx.decodeAudioData(arraybuffer, handle, onError);
+	  }
+	}
 
   /**
    * Sound is now loaded, so finish setting everything up and fire the loaded event.


### PR DESCRIPTION
I noticed than decodeAudioData of AudioContext has only one parameter and sometime callback passed in to decodeAudioData dont fire at all. I added checking to handle events via promise syntax in modern browsers.
For me this fix solved problem of frozen preloader which happened randomly.