### PR TITLE
Fix typo

### DIFF
--- a/examples/player/player.js
+++ b/examples/player/player.js
@@ -79,7 +79,7 @@ Player.prototype = {
           // Stop the wave animation.
           wave.container.style.display = 'none';
           bar.style.display = 'block';
-          self.skip('right');
+          self.skip('next');
         },
         onpause: function() {
           // Stop the wave animation.


### PR DESCRIPTION
Since it's call skip('next'), it's better to use the same wording