### PR TITLE
IE11 play is undefined addresses #1015

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -781,7 +781,7 @@
             var play = node.play();
 
             // Support older browsers that don't support promises, and thus don't have this issue.
-            if (typeof Promise !== 'undefined' && (play instanceof Promise || typeof play.then === 'function')) {
+            if (play && typeof Promise !== 'undefined' && (play instanceof Promise || typeof play.then === 'function')) {
               // Implements a lock to prevent DOMException: The play() request was interrupted by a call to pause().
               self._playLock = true;
 


### PR DESCRIPTION
Fixes "Unable to get property 'then' of undefined or null reference" in IE11