### PR TITLE
Safari fix for panner.setPosition

### DIFF
--- a/src/plugins/howler.spatial.js
+++ b/src/plugins/howler.spatial.js
@@ -313,7 +313,7 @@
               sound._panner.positionY.setValueAtTime(y, Howler.ctx.currentTime);
               sound._panner.positionZ.setValueAtTime(z, Howler.ctx.currentTime);
             } else {
-              sound._panner.setOrientation(x, y, z);
+              sound._panner.setPosition(x, y, z);
             }
           }
 


### PR DESCRIPTION
This fixes setting the panner position in Safari browsers. It was using setOrientation where setPosition is needed.