### PR TITLE
Enable mobile audio now required for Safari 12

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -279,7 +279,7 @@
       var self = this || Howler;
 
       // Only run this on mobile devices if audio isn't already eanbled.
-      var isMobile = /iPhone|iPad|iPod|Android|BlackBerry|BB10|Silk|Mobi|Chrome/i.test(self._navigator && self._navigator.userAgent);
+      var isMobile = /iPhone|iPad|iPod|Android|BlackBerry|BB10|Silk|Mobi|Chrome|Safari/i.test(self._navigator && self._navigator.userAgent);
       if (self._mobileEnabled || !self.ctx || !isMobile) {
         return;
       }


### PR DESCRIPTION
Safari 12, which was just released, now has the same restriction as iOS Safari that requires user interaction to enable audio if "Auto-Play" is not allowed in the website settings, which is the default.  This hotfix includes Safari in the list of browsers to check in order to auto-enable audio on Safari 12 by default.

There's been some talk of refactoring the name of `mobileAutoEnable` as a future "breaking change" in #939 since this check isn't just for mobile anymore (we're already doing it in Chrome), however this hotfix is required so that playback works as expected in Safari 12 today.