### PR TITLE
Fix `InvalidStateError` on IE11 when playing sound

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -1480,7 +1480,7 @@
           self._clearTimer(id);
 
           // Update the seek position for HTML5 Audio.
-          if (!self._webAudio && sound._node) {
+          if (!self._webAudio && sound._node && !isNaN(sound._node.duration)) {
             sound._node.currentTime = seek;
           }
 


### PR DESCRIPTION
In our use of howler.js, IE11 is throwing an `InvalidStateError`, but the problem is resolved by making sure we can set `currentTime` on this line