### PR TITLE
fix play to avoid starting from beginning after pause

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -717,6 +717,15 @@
       } else if (typeof sprite === 'undefined') {
         // Use the default sound sprite (plays the full audio length).
         sprite = '__default';
+
+        // Check if there is a single paused sound that isn't ended.
+        // If there is, play that sound. If not, continue as usual.
+        for (var i = 0; i < self._sounds.length; i++) {
+          if (self._sounds[i]._paused && !self._sounds[i]._ended) {
+            id = self._sounds[i]._id;
+            break;
+          }
+        }
       }
 
       // Get the selected node, or get one from the pool.


### PR DESCRIPTION
When playing a 'paused' howl, we were instanciating a new `sound` every
time.
Instead we should use the existing `sound` if:
 - `_paused === true`
 - `_ended === false`

This basically rollbacks this commit https://github.com/goldfire/howler.js/commit/be4e4453c955170327e247bdd8837f74aead6389#diff-1e099b745600c69cbaacbe86736975fc

fixes #1101