### PR TITLE
Fix Infinity duration when html5 flag is setted

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -1667,7 +1667,13 @@
       // If we pass an ID, get the sound and return the sprite length.
       var sound = self._soundById(id);
       if (sound) {
-        duration = self._sprite[sound._sprite][1] / 1000;
+        if(self._webAudio === false){
+          //HTML5
+          duration = sound._node.duration;
+        } else {
+          //WEB AUDIO
+          duration = self._sprite[sound._sprite][1] / 1000;
+        }
       }
 
       return duration;


### PR DESCRIPTION
Sometimes if html5 flag is setted duration() method is returning Infinity value. Reproduced for me when I was playing a recording just recorded with a microphone a moment before.