### PR TITLE
Added HTTP method setting to user-defined properties

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -560,6 +560,7 @@
       self._src = (typeof o.src !== 'string') ? o.src : [o.src];
       self._volume = o.volume !== undefined ? o.volume : 1;
       self._xhrWithCredentials = o.xhrWithCredentials || false;
+      self._method = o.method || "GET"
 
       // Setup all other default properties.
       self._duration = 0;
@@ -718,8 +719,8 @@
         // Use the default sound sprite (plays the full audio length).
         sprite = '__default';
 
-        // Check if there is a single paused sound that isn't ended. 
-        // If there is, play that sound. If not, continue as usual.  
+        // Check if there is a single paused sound that isn't ended.
+        // If there is, play that sound. If not, continue as usual.
         if (!self._playLock) {
           var num = 0;
           for (var i=0; i<self._sounds.length; i++) {
@@ -2303,7 +2304,7 @@
     } else {
       // Load the buffer from the URL.
       var xhr = new XMLHttpRequest();
-      xhr.open('GET', url, true);
+      xhr.open(self._method, url, true);
       xhr.withCredentials = self._xhrWithCredentials;
       xhr.responseType = 'arraybuffer';
       xhr.onload = function() {


### PR DESCRIPTION
This allows more flexibility with HTTP requests used for fetching the sound data. You can now just write it like this...

![image](https://user-images.githubusercontent.com/15697697/52887383-c9eafa80-3177-11e9-98e5-b92eccf40779.png)

...instead of diving into the source code to edit it out. Defaults to "GET" if you don't put anything. 
Your tests passed for me with this change.