### PR TITLE
Radio: Stopping stream must also stop downloading

### DIFF
--- a/examples/radio/radio.js
+++ b/examples/radio/radio.js
@@ -90,6 +90,7 @@ Radio.prototype = {
     // Stop the sound.
     if (sound) {
       sound.stop();
+      sound.unload();
     }
   },
 


### PR DESCRIPTION
All streams will download simultaneously in the background, which is a bit selfish.

Let's unload streams we're not listening to.

Closes #1143.