### PR TITLE
Fix for the issue with volume reset after _unlockAudio()

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -2459,7 +2459,7 @@
     // Create and expose the master GainNode when using Web Audio (useful for plugins or advanced usage).
     if (Howler.usingWebAudio) {
       Howler.masterGain = (typeof Howler.ctx.createGain === 'undefined') ? Howler.ctx.createGainNode() : Howler.ctx.createGain();
-      Howler.masterGain.gain.setValueAtTime(Howler._muted ? 0 : 1, Howler.ctx.currentTime);
+      Howler.masterGain.gain.setValueAtTime(Howler._muted ? 0 : Howler._volume, Howler.ctx.currentTime);
       Howler.masterGain.connect(Howler.ctx.destination);
     }
 


### PR DESCRIPTION
If the main volume was set before _unlockAudio() is called - it had been resetting to 1.