### PR TITLE
Added simplified stereo plugin

### DIFF
--- a/src/plugins/howler.stereo.js
+++ b/src/plugins/howler.stereo.js
@@ -193,9 +193,8 @@
   /**
    * Create a new panner node and save it on the sound.
    * @param  {Sound} sound Specific sound to setup panning on.
-   * @param {String} type Type of panner to create: 'stereo' or 'spatial'.
    */
-  var setupPanner = function(sound, type) {
+  var setupPanner = function(sound) {
     sound._panner = Howler.ctx.createStereoPanner();
     sound._panner.pan.setValueAtTime(sound._stereo, Howler.ctx.currentTime);
     sound._panner.connect(sound._node);

--- a/src/plugins/howler.stereo.js
+++ b/src/plugins/howler.stereo.js
@@ -1,0 +1,208 @@
+/*!
+ *  Stereo Plugin - Adds support for stereo where Web Audio is supported.
+ *  
+ *  howler.js v2.1.2
+ *  howlerjs.com
+ *
+ *  (c) 2013-2019, James Simpson of GoldFire Studios
+ *  goldfirestudios.com
+ *
+ *  MIT License
+ */
+
+(function() {
+
+  'use strict';
+
+  /** Global Methods **/
+  /***************************************************************************/
+
+  /**
+   * Helper method to update the stereo panning position of all current Howls.
+   * Future Howls will not use this value unless explicitly set.
+   * @param  {Number} pan A value of -1.0 is all the way left and 1.0 is all the way right.
+   * @return {Howler/Number}     Self or current stereo panning value.
+   */
+  HowlerGlobal.prototype.stereo = function(pan) {
+    var self = this;
+
+    // Stop right here if not using Web Audio.
+    if (!self.ctx || !self.ctx.listener) {
+      return self;
+    }
+
+    // Loop through all Howls and update their stereo panning.
+    for (var i=self._howls.length-1; i>=0; i--) {
+      self._howls[i].stereo(pan);
+    }
+
+    return self;
+  };
+
+  /** Group Methods **/
+  /***************************************************************************/
+
+  /**
+   * Add new properties to the core init.
+   * @param  {Function} _super Core init method.
+   * @return {Howl}
+   */
+  Howl.prototype.init = (function(_super) {
+    return function(o) {
+      var self = this;
+
+      // Setup user-defined default properties.
+      self._stereo = o.stereo || null;
+      self._pannerAttr = {
+        pan: typeof o.pan !== 'undefined' ? o.pan : 0,
+      };
+
+      // Setup event listeners.
+      self._onstereo = o.onstereo ? [{fn: o.onstereo}] : [];
+
+      // Complete initilization with howler.js core's init function.
+      return _super.call(this, o);
+    };
+  })(Howl.prototype.init);
+
+  /**
+   * Get/set the stereo panning of the audio source for this sound or all in the group.
+   * @param  {Number} pan  A value of -1.0 is all the way left and 1.0 is all the way right.
+   * @param  {Number} id (optional) The sound ID. If none is passed, all in group will be updated.
+   * @return {Howl/Number}    Returns self or the current stereo panning value.
+   */
+  Howl.prototype.stereo = function(pan, id) {
+    var self = this;
+
+    // Stop right here if not using Web Audio.
+    if (!self._webAudio) {
+      return self;
+    }
+
+    // If the sound hasn't loaded, add it to the load queue to change stereo pan when capable.
+    if (self._state !== 'loaded') {
+      self._queue.push({
+        event: 'stereo',
+        action: function() {
+          self.stereo(pan, id);
+        }
+      });
+
+      return self;
+    }
+
+    // Setup the group's stereo panning if no ID is passed.
+    if (typeof id === 'undefined') {
+      // Return the group's stereo panning if no parameters are passed.
+      if (typeof pan === 'number') {
+        self._stereo = pan;
+      } else {
+        return self._stereo;
+      }
+    }
+
+    // Change the streo panning of one or all sounds in group.
+    var ids = self._getSoundIds(id);
+    for (var i=0; i<ids.length; i++) {
+      // Get the sound.
+      var sound = self._soundById(ids[i]);
+
+      if (sound) {
+        if (typeof pan === 'number') {
+          sound._stereo = pan;
+
+          if (sound._node) {
+            // Check if there is a panner setup and create a new one if not.
+            if (!sound._panner || !sound._panner.pan) {
+              setupPanner(sound);
+            }
+
+            sound._panner.pan.setValueAtTime(pan, Howler.ctx.currentTime);            
+          }
+
+          self._emit('stereo', sound._id);
+        } else {
+          return sound._stereo;
+        }
+      }
+    }
+
+    return self;
+  };
+
+
+  /** Single Sound Methods **/
+  /***************************************************************************/
+
+  /**
+   * Add new properties to the core Sound init.
+   * @param  {Function} _super Core Sound init method.
+   * @return {Sound}
+   */
+  Sound.prototype.init = (function(_super) {
+    return function() {
+      var self = this;
+      var parent = self._parent;
+
+      // Setup user-defined default properties.
+      self._stereo = parent._stereo;
+      self._pannerAttr = parent._pannerAttr;
+
+      // Complete initilization with howler.js core Sound's init function.
+      _super.call(this);
+
+      // If a stereo or position was specified, set it up.
+      if (self._stereo) {
+        parent.stereo(self._stereo);
+      }
+    };
+  })(Sound.prototype.init);
+
+  /**
+   * Override the Sound.reset method to clean up properties from the spatial plugin.
+   * @param  {Function} _super Sound reset method.
+   * @return {Sound}
+   */
+  Sound.prototype.reset = (function(_super) {
+    return function() {
+      var self = this;
+      var parent = self._parent;
+
+      // Reset all spatial plugin properties on this sound.
+      self._stereo = parent._stereo;
+      self._pannerAttr = parent._pannerAttr;
+
+      // If a stereo or position was specified, set it up.
+      if (self._stereo) {
+        parent.stereo(self._stereo);
+      } else if (self._panner) {
+        // Disconnect the panner.
+        self._panner.disconnect(0);
+        self._panner = undefined;
+        parent._refreshBuffer(self);
+      }
+
+      // Complete resetting of the sound.
+      return _super.call(this);
+    };
+  })(Sound.prototype.reset);
+
+  /** Helper Methods **/
+  /***************************************************************************/
+
+  /**
+   * Create a new panner node and save it on the sound.
+   * @param  {Sound} sound Specific sound to setup panning on.
+   * @param {String} type Type of panner to create: 'stereo' or 'spatial'.
+   */
+  var setupPanner = function(sound, type) {
+    sound._panner = Howler.ctx.createStereoPanner();
+    sound._panner.pan.setValueAtTime(sound._stereo, Howler.ctx.currentTime);
+    sound._panner.connect(sound._node);
+
+    // Update the connections.
+    if (!sound._paused) {
+      sound._parent.pause(sound._id, true).play(sound._id, true);
+    }
+  };
+})();

--- a/tests/js/stereo.js
+++ b/tests/js/stereo.js
@@ -1,0 +1,83 @@
+// Cache the label for later use.
+var label = document.getElementById('label');
+var start = document.getElementById('start');
+
+// Setup the sounds to be used.
+var sound1 = new Howl({
+  src: ['audio/sound1.webm', 'audio/sound1.mp3']
+});
+
+var sound2 = new Howl({
+  src: ['audio/sound2.webm', 'audio/sound2.mp3'],
+  sprite: {
+    one: [0, 450],
+    two: [2000, 250],
+    three: [4000, 350],
+    four: [6000, 380],
+    five: [8000, 340],
+    beat: [10000, 11163]
+  }
+});
+
+// Enable the start button when the sounds have loaded.
+sound1.once('load', function() {
+  start.removeAttribute('disabled');
+  start.innerHTML = 'BEGIN STEREO TESTS';
+});
+
+// Define the tests to run.
+var id;
+var tests = [
+  function(fn) {
+    sound1.once('play', function() {
+      label.innerHTML = 'PLAYING';
+      setTimeout(fn, 2000);
+    });
+    
+    id = sound1.play();
+  },
+
+  function(fn) {
+    sound1.stereo(-1, id);
+
+    label.innerHTML = 'LEFT STEREO';
+    setTimeout(fn, 2000);
+  },
+
+  function(fn) {
+    sound1.stereo(1, id);
+
+    label.innerHTML = 'RIGHT STEREO';
+    setTimeout(function() {
+      fn();
+    }, 2000);
+  }
+];
+
+// Create a method that will call the next in the series.
+var chain = function(i) {
+  return function() {
+    if (tests[i]) {
+      tests[i](chain(++i));
+    } else {
+      label.innerHTML = 'COMPLETE!';
+      label.style.color = '#74b074';
+
+      // Wait for 5 seconds and then go back to the tests index.
+      setTimeout(function() {
+        window.location = './';
+      }, 5000);
+    }
+  };
+};
+
+// If Web Audio isn't available, send them to hTML5 test.
+if (Howler.usingWebAudio) {
+  // Listen to a click on the button to being the tests.
+  start.addEventListener('click', function() {
+    tests[0](chain(1));
+    start.style.display = 'none';
+  }, false);
+} else {
+  window.location = 'core.html5audio.html';
+}

--- a/tests/stereo.html
+++ b/tests/stereo.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Howler.js Spatial Plugin Tests</title>
+  <link rel="stylesheet" href="./css/styles.css">
+</head>
+<body>
+  <div id="container">
+    <div id="label"></div>
+    <button class="button" id="start" disabled>LOADING...</button>
+  </div>
+  <script src="../src/howler.core.js"></script>
+  <script src="../src/plugins/howler.stereo.js"></script>
+  <script src="./js/stereo.js"></script>
+</body>
+</html>


### PR DESCRIPTION
I'm not really sure how useful this is considering that it has fewer features than the spatial plugin and higher browser requirements, but I wrote this while working  on a different plugin (to learn how they worked) so I thought I might as well share it. 

It might also be useful as a simpler plugin example... or if you don't need positional audio support and could really use a 4kb lighter package. Yeah.

As title says, it's a simplified stereo plugin that uses a simple StereoPannerNode. It includes tests and everything.

Not sure what kind of attribution should I use on the header comment since it seems to be autogenerated. Considering that I just removed code from existing files, I'm not really worried about this.