### PR TITLE
Fixed audio not looping occasionally

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -796,7 +796,6 @@
       var timeout = (duration * 1000) / Math.abs(sound._rate);
       var start = self._sprite[sprite][0] / 1000;
       var stop = (self._sprite[sprite][0] + self._sprite[sprite][1]) / 1000;
-      var loop = !!(sound._loop || self._sprite[sprite][2]);
       sound._sprite = sprite;
 
       // Mark the sound as ended instantly so that this async playback
@@ -809,7 +808,7 @@
         sound._seek = seek;
         sound._start = start;
         sound._stop = stop;
-        sound._loop = loop;
+        sound._loop = !!(sound._loop || self._sprite[sprite][2]);
       };
 
       // End the sound instantly if seek is at the end.


### PR DESCRIPTION
Finally upgrade to the latest Howler after sitting on a version from early 2018 for ages!

I can across a bug in games where the background audio would sometimes not loop. Sometimes it did, and I couldn't work out why and when it sometimes did work and sometimes didn't. When setting a breakpoint around this area, the background looping _always_ worked, which made things even more infuriating.

Eventually I came to this simple change. If you play a sound, and it doesn't have the looping property set, but then set it straight after playing; well, it appears there's this tiny race condition. It's something like this:
You play the audio, and when getting the id back, you set the audio to pause. But web audio isn't ready yet; so when it finally IS ready setParams is called later on than usual, and resets the loop property to it's original value of false.