### PR TITLE
Simplifying a boolean expression

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -721,8 +721,8 @@
         // Use the default sound sprite (plays the full audio length).
         sprite = '__default';
 
-        // Check if there is a single paused sound that isn't ended. 
-        // If there is, play that sound. If not, continue as usual.  
+        // Check if there is a single paused sound that isn't ended.
+        // If there is, play that sound. If not, continue as usual.
         if (!self._playLock) {
           var num = 0;
           for (var i=0; i<self._sounds.length; i++) {
@@ -2450,7 +2450,7 @@
     var version = appVersion ? parseInt(appVersion[1], 10) : null;
     if (iOS && version && version < 9) {
       var safari = /safari/.test(Howler._navigator && Howler._navigator.userAgent.toLowerCase());
-      if (Howler._navigator && Howler._navigator.standalone && !safari || Howler._navigator && !Howler._navigator.standalone && !safari) {
+      if (Howler._navigator && !safari) {
         Howler.usingWebAudio = false;
       }
     }


### PR DESCRIPTION
Let me explain the simplification.

With `Howler._navigator` as `A`,  `Howler._navigator.standalone` as `B` and `!safari` as `C`

The complete expression will be `(A & B & C | A & !B & C)`. Repleacing the and's as multiplications and the or's as additions you could move A and C outsite of the ecuation. `(A * B * C + A * !B * C) -> (A * C) * (B + !B)`.

So, you'll have `(A & C) & (B | !B)`. B or !B it's allways true, ergo you have `A & C` as your resultant expression. And `A` it's only used to avoid a possible runtime error I guess