### PR TITLE
Fix leaks when audio context cannot be unlocked (MacOS Safari)

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -326,7 +326,7 @@
         // to the WebAudio API which only needs a single activation.
         // This must occur before WebAudio setup or the source.onended
         // event will not fire.
-        for (var i=0; i<self.html5PoolSize; i++) {
+        while (self._html5AudioPool.length < self.html5PoolSize) {
           try {
             var audioNode = new Audio();
 
@@ -338,6 +338,7 @@
             self._releaseHtml5Audio(audioNode);
           } catch (e) {
             self.noAudio = true;
+            break;
           }
         }
 


### PR DESCRIPTION
Symptom is the _html5AudioPool fills with unbounded number of elements if unable to unlock (seen on MacOS Safari).

When not allowed to unlock audio, we're seeing `unlock` being called on every touch event indefinitely, leaking Audio elements, causing a big slowdown in our app after a few minutes.  This happens on Mac OS Safari when audio is not allowed to be unlocked (microphone was in use by another tab, I think).

It appears to also be thrashing AudioBufferSources and related state as it keeps making new sources and trying to play them and binding new onended callbacks, but I don't see an easy way around that.

My fork has diverged quite a bit, but I think this PR captures the change into the right place for the mainline.

