### PR TITLE
if audioelement exists use it on obtainhtml5audio

### DIFF
--- a/dist/howler.js
+++ b/dist/howler.js
@@ -416,9 +416,13 @@
     _obtainHtml5Audio: function() {
       var self = this || Howler;
 
+      //Gets an existing audio element
+      let audioelement = document.getElementById("audioelement");
+
       // Return the next object from the pool if one exists.
       if (self._html5AudioPool.length) {
-        return self._html5AudioPool.pop();
+        //If exists a object alredy on DOM, it is better to manipulate him
+        return (audioelement !== null) ? audioelement : self._html5AudioPool.pop();
       }
 
       //.Check if the audio is locked and throw a warning.
@@ -429,7 +433,7 @@
         });
       }
 
-      return new Audio();
+      return (audioelement !== null) ? audioelement : self._html5AudioPool.pop();
     },
 
     /**

--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -416,9 +416,13 @@
     _obtainHtml5Audio: function() {
       var self = this || Howler;
 
+      //Gets an existing audio element
+      let audioelement = document.getElementById("audioelement");
+
       // Return the next object from the pool if one exists.
       if (self._html5AudioPool.length) {
-        return self._html5AudioPool.pop();
+        //If exists a object alredy on DOM, it is better to manipulate him
+        return (audioelement !== null) ? audioelement : self._html5AudioPool.pop();
       }
 
       //.Check if the audio is locked and throw a warning.
@@ -429,7 +433,7 @@
         });
       }
 
-      return new Audio();
+      return (audioelement !== null) ? audioelement : self._html5AudioPool.pop();
     },
 
     /**


### PR DESCRIPTION
refers to #1360 

As i could notice, on Android Webview, somehow it needed a user interaction, leading to a catch promise:
Playback was unable to start. This is most commonly an issue...

As a solution, if i have an audio element on my web page, i dont need this user gesture and the show keeps going on :D