### PR TITLE
fix wav support in Safari 14

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -273,7 +273,7 @@
         opus: !!audioTest.canPlayType('audio/ogg; codecs="opus"').replace(/^no$/, ''),
         ogg: !!audioTest.canPlayType('audio/ogg; codecs="vorbis"').replace(/^no$/, ''),
         oga: !!audioTest.canPlayType('audio/ogg; codecs="vorbis"').replace(/^no$/, ''),
-        wav: !!audioTest.canPlayType('audio/wav; codecs="1"').replace(/^no$/, ''),
+        wav: !!(audioTest.canPlayType('audio/wav; codecs="1"') || audioTest.canPlayType('audio/wav')).replace(/^no$/, ''),
         aac: !!audioTest.canPlayType('audio/aac;').replace(/^no$/, ''),
         caf: !!audioTest.canPlayType('audio/x-caf;').replace(/^no$/, ''),
         m4a: !!(audioTest.canPlayType('audio/x-m4a;') || audioTest.canPlayType('audio/m4a;') || audioTest.canPlayType('audio/aac;')).replace(/^no$/, ''),


### PR DESCRIPTION
Howler.js 2.2.0 doesn't play WAV files in Safari 14, because this method is returning empty string (i.e. false) in Safari 14: `audioTest.canPlayType('audio/wav; codecs="1"')`. I created an issue for it: #1414
So I added another option without specifying `codecs` attribute which fix this. Here is demo to test it: https://stackblitz.com/edit/js-bvgnv8?file=index.js