### PR TITLE
Include keydown event when unlocking audio

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -392,6 +392,7 @@
           document.removeEventListener('touchstart', unlock, true);
           document.removeEventListener('touchend', unlock, true);
           document.removeEventListener('click', unlock, true);
+          document.removeEventListener('keydown', unlock, true);
 
           // Let all sounds know that audio has been unlocked.
           for (var i=0; i<self._howls.length; i++) {
@@ -404,6 +405,7 @@
       document.addEventListener('touchstart', unlock, true);
       document.addEventListener('touchend', unlock, true);
       document.addEventListener('click', unlock, true);
+      document.addEventListener('keydown', unlock, true);
 
       return self;
     },


### PR DESCRIPTION
To allow users with accessibility issues use our site we needed to support "unlocking" Howler using non-click/touch based events. The `keydown` event seemed the most appropriate.

I noticed there have been other discussions that have skirted around expanding on the existing list of events that trigger the unlock but I couldn't find anything concrete.

@oswaldofreitas mentioned in #1294 about using:
```
  'click',
  'contextmenu',
  'auxclick',
  'dblclick',
  'mousedown',
  'mouseup',
  'pointerup',
  'touchend',
  'keydown',
  'keyup',
```

And @Jimbly appears to be listening for
```
touchstart, touchend, click, mousedown and keydown
```
https://github.com/Jimbly/howler.js/blob/master/src/howler.core.js#L433-L438

In the short term at least, adding `keydown` (and maybe `keyup`?) would help with the accessibility issues.

Great project BTW 👍 