### PR TITLE
fix: check that sounds are loaded in seek (returning current position)

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -1582,7 +1582,9 @@
       // Determine the values based on arguments.
       if (args.length === 0) {
         // We will simply return the current position of the first node.
-        id = self._sounds[0]._id;
+        if (self._sounds.length) {
+          id = self._sounds[0]._id;
+        }
       } else if (args.length === 1) {
         // First check if this is an ID, and if not, assume it is a new seek position.
         var ids = self._getSoundIds();


### PR DESCRIPTION
If sounds are not loaded and calls `.seek()` you get this error:

```
Cannot read property '_id' of undefined
```