### PR TITLE
fix(seek): execute queue items added while buffering

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -913,7 +913,7 @@
                 .then(function() {
                   self._playLock = false;
                   node._unlocked = true;
-                  if(!internal){
+                  if (!internal) {
                     self._emit('play', sound._id);
                   }
                   if (!skipQueue) {
@@ -936,7 +936,7 @@
                 self._emit('play', sound._id);
               }
 
-              if(!skipQueue){
+              if (!skipQueue) {
                 self._loadQueue();
               }
             }
@@ -985,7 +985,7 @@
           var listener = function() {
             // Begin playback.
             playHtml5(false);
-            
+
             // Clear this listener.
             node.removeEventListener(Howler._canPlayEvent, listener, false);
           };


### PR DESCRIPTION
Fixes https://github.com/goldfire/howler.js/issues/1439

Do not skip the queue if play has been called internally from seek, but after buffering. 

Video fix:

https://user-images.githubusercontent.com/755469/104257442-73fa5c80-544b-11eb-8955-66dcd3a39fb8.mp4

