### PR TITLE
fix: set state to loading when sound is buffering

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -974,8 +974,11 @@
           playHtml5();
         } else {
           self._playLock = true;
+          self._state = 'loading';
 
           var listener = function() {
+            self._state = 'loaded';
+            
             // Begin playback.
             playHtml5();
 


### PR DESCRIPTION
Set the state to loading when the player is buffering. This is useful so that when the user seeks a sound, but the sound was not fully loaded, we can adjust the UI to show that is it still loading