### PR TITLE
HTML5 mode fails to stop sprite playback when sound played repeatedly

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -921,7 +921,6 @@
                   node._unlocked = true;
                   if (!internal) {
                     self._emit('play', sound._id);
-                  } else {
                     self._loadQueue();
                   }
                 })
@@ -938,6 +937,7 @@
               self._playLock = false;
               setParams();
               self._emit('play', sound._id);
+              self._loadQueue();
             }
 
             // Setting rate before playing won't work in IE, so we set it again here.


### PR DESCRIPTION
After upgrading Howler from 2.2.1 to 2.2.3, and using HTML5 mode on Safari 15 as a work-around for Catalina (#1513), I identified a bug where audio sprites fail to stop playback after the desired sound has played:

1. Play a sound from an audio sprite over and over again in HTML mode, so that the sound plays again while the previous sound is already playing.
1. Keep doing this until you observe that the audio sprite fails to stop playing, and continues to play through the rest of the audio file, confusing end users with all of the unexpected sounds!

This is always an issue on Internet Explorer 11 with the latest howler version, since IE uses HTML5 audio.

I identified this as a regression from 0323af9b843351cacc47893aed8e65cd8ba3b0cb (fix for #1439).  I do not know if this PR will re-introduce that bug. It definitely solves this new issue though (I'm using this fix in production and confirmed it solves the problem on Safari 15 with HTML5 mode and IE11).