### PR TITLE
fix: audio cannot play after unplugging headphones on IOS

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -521,7 +521,7 @@
       if (self.state === 'running' && self.ctx.state !== 'interrupted' && self._suspendTimer) {
         clearTimeout(self._suspendTimer);
         self._suspendTimer = null;
-      } else if (self.state === 'suspended' || self.state === 'running' && self.ctx.state === 'interrupted') {
+      } else if (self.state === 'suspended' || self.state === 'running' && (self.ctx.state === 'interrupted' || self.ctx.state === 'suspended')) {
         self.ctx.resume().then(function() {
           self.state = 'running';
 


### PR DESCRIPTION
Fixes #1355
On iOS, when you unplug headphones, its policy will suspend any AudioContext and Howler.ctx.state is changed to 'suspended'. But In the `_autoResume` function, AudioContext can only be resumed when Howler state is 'suspended' or Howler state is 'running' and Howler.ctx.state is 'interrupted':
https://github.com/goldfire/howler.js/blob/f128f9d975c2bc87610eac0eab5239980b3a4dda/src/howler.core.js#L524

_Originally posted in https://github.com/goldfire/howler.js/issues/1355#issuecomment-1017190371_
