### PR TITLE
Fix seek not updating currentTime

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "howler",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Javascript audio library for the modern web.",
   "homepage": "https://howlerjs.com",
   "keywords": [

--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -1649,7 +1649,7 @@
           self._clearTimer(id);
 
           // Update the seek position for HTML5 Audio.
-          if (!self._webAudio && sound._node && !isNaN(sound._node.duration)) {
+          if (!self._webAudio && sound._node) {
             sound._node.currentTime = seek;
           }
 


### PR DESCRIPTION
### Issue/Feature
Using html5 the seek function do not update the audio currentTime consistently, this cause the seek() to sometimes return incorrect timestamp value. 

### Related Issues
I've not created issue because I cannot release code associated to the issue.

### Solution
I've noticed that the currentTime update depends on the presence of duration, this is why sometimes the currentTime is not updated.

### Reproduction/Testing
Reproduction is not easy but you could try to creat an animationFrame using html5 audio to get seek value and update it regularly and see that if audio has no duration set it would not update.

### Breaking Changes
N/A

### Release
I couldn't create a release because `npm run build` failed on my machine because of the `sed` part.