### PR TITLE
Feature: add eager playback global option

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,9 +380,9 @@ Each HTML5 Audio object must be unlocked individually, so we keep a global pool 
 Automatically suspends the Web Audio AudioContext after 30 seconds of inactivity to decrease processing and energy usage. Automatically resumes upon new playback. Set this property to `false` to disable this behavior.
 #### eagerPlayback `Boolean` `false`
 When enabled, allows playback to begin before the browser has estimated that enough data has loaded in order to play the sound to its end, without having to stop and buffer for more content.
-#### ctx `Boolean` *`Web Audio Only`*
+#### ctx `AudioContext` `null` *`Web Audio Only`*
 Exposes the `AudioContext` with Web Audio API.
-#### masterGain `Boolean` *`Web Audio Only`*
+#### masterGain `GainNode` `null` *`Web Audio Only`*
 Exposes the master `GainNode` with Web Audio API. This can be useful for writing plugins or advanced usage.
 
 

--- a/README.md
+++ b/README.md
@@ -378,6 +378,8 @@ Automatically attempts to enable audio on mobile (iOS, Android, etc) devices and
 Each HTML5 Audio object must be unlocked individually, so we keep a global pool of unlocked nodes to share between all `Howl` instances. This pool gets created on the first user interaction and is set to the size of this property.
 #### autoSuspend `Boolean` `true`
 Automatically suspends the Web Audio AudioContext after 30 seconds of inactivity to decrease processing and energy usage. Automatically resumes upon new playback. Set this property to `false` to disable this behavior.
+#### eagerPlayback `Boolean` `false`
+When enabled, allows playback to begin before the browser has estimated that enough data has loaded in order to play the sound to its end, without having to stop and buffer for more content.
 #### ctx `Boolean` *`Web Audio Only`*
 Exposes the `AudioContext` with Web Audio API.
 #### masterGain `Boolean` *`Web Audio Only`*

--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -918,7 +918,8 @@
       } else {
         // Fire this when the sound is ready to play to begin HTML5 Audio playback.
         var playHtml5 = function() {
-          // When `eagerPlayback` is enabled, setting `currentTime` to the same value prevents the play promise from ever resolving.
+          // When `eagerPlayback` is enabled, setting `currentTime` to the same value prevents the
+          // play promise from ever resolving in Chromium-based browsers.
           if (node.currentTime !== seek) {
             node.currentTime = seek;
           }

--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -918,7 +918,7 @@
       } else {
         // Fire this when the sound is ready to play to begin HTML5 Audio playback.
         var playHtml5 = function() {
-          // When `eagerPlayback` is enabled, setting `currentTime` to the same value prevents the play promise from ever resolving
+          // When `eagerPlayback` is enabled, setting `currentTime` to the same value prevents the play promise from ever resolving.
           if (node.currentTime !== seek) {
             node.currentTime = seek;
           }

--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -918,7 +918,9 @@
       } else {
         // Fire this when the sound is ready to play to begin HTML5 Audio playback.
         var playHtml5 = function() {
-          node.currentTime = seek;
+          if (node.currentTime !== seek) {
+            node.currentTime = seek;
+          }
           node.muted = sound._muted || self._muted || Howler._muted || node.muted;
           node.volume = sound._volume * Howler.volume();
           node.playbackRate = sound._rate;

--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -549,7 +549,7 @@
      * play without stopping and buffering additional data.
      * @return {Howler}
      */
-    _setEagerPlayback: function() {
+    _enableEagerPlayback: function() {
       var self = this;
 
       if (self._canPlayEvent === 'canplaythrough') {
@@ -641,7 +641,7 @@
       self._webAudio = Howler.usingWebAudio && !self._html5;
 
       if (Howler.eagerPlayback) {
-        Howler._setEagerPlayback();
+        Howler._enableEagerPlayback();
       }
 
       // Automatically try to enable audio.

--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -918,6 +918,7 @@
       } else {
         // Fire this when the sound is ready to play to begin HTML5 Audio playback.
         var playHtml5 = function() {
+          // When `eagerPlayback` is enabled, setting `currentTime` to the same value prevents the play promise from ever resolving
           if (node.currentTime !== seek) {
             node.currentTime = seek;
           }

--- a/tests/core.html5audio.html
+++ b/tests/core.html5audio.html
@@ -12,6 +12,7 @@
     <div id="logo"></div>
   </div>
   <script src="../src/howler.core.js"></script>
+  <script src="./js/parseGlobalOptions.js"></script>
   <script src="./js/core.html5audio.js"></script>
 </body>
 </html>

--- a/tests/core.webaudio.html
+++ b/tests/core.webaudio.html
@@ -11,6 +11,7 @@
     <button class="button" id="start" disabled>LOADING...</button>
   </div>
   <script src="../src/howler.core.js"></script>
+  <script src="./js/parseGlobalOptions.js"></script>
   <script src="./js/core.webaudio.js"></script>
 </body>
 </html>

--- a/tests/css/styles.css
+++ b/tests/css/styles.css
@@ -1,6 +1,6 @@
 html {
   width: 100%;
-  height: 100%;  
+  height: 100%;
   overflow: hidden;
   padding: 0;
   margin: 0;
@@ -87,6 +87,23 @@ body {
   -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+#globalOptions {
+  margin-bottom: 2rem;
+}
+
+#globalOptions h6 {
+  font-size: 4vw;
+  margin: 0 0 1rem;
+}
+
+.option {
+  font-size: 2vw;
+}
+
+label {
+  vertical-align: middle;
 }
 
 @media screen and (max-height: 400px) {

--- a/tests/css/styles.css
+++ b/tests/css/styles.css
@@ -98,7 +98,7 @@ body {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  width: 100%;
+  width: 92%;
   margin: 0 2rem 3rem;
 }
 

--- a/tests/css/styles.css
+++ b/tests/css/styles.css
@@ -89,17 +89,22 @@ body {
   align-items: center;
 }
 
-#globalOptions {
-  margin-bottom: 2rem;
+#globalOptionsHeader {
+  font-size: 3vw;
+  margin: 0 0 1rem;
 }
 
-#globalOptions h6 {
-  font-size: 4vw;
-  margin: 0 0 1rem;
+#globalOptions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  width: 100%;
+  margin: 0 2rem 3rem;
 }
 
 .option {
   font-size: 2vw;
+  margin-right: 3rem;
 }
 
 label {

--- a/tests/css/styles.css
+++ b/tests/css/styles.css
@@ -103,12 +103,28 @@ body {
 }
 
 .option {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  -webkit-justify-content: space-between;
+  -webkit-box-pack: justify;
+  -ms-flex-pack: distribute;
+  justify-content: space-between;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin: 0 2rem 1rem 0;
   font-size: 2vw;
-  margin-right: 3rem;
 }
 
-label {
-  vertical-align: middle;
+.option > * {
+  margin-bottom: 0;
+}
+
+.option > label {
+  margin-right: 0.5rem;
 }
 
 @media screen and (max-height: 400px) {

--- a/tests/index.html
+++ b/tests/index.html
@@ -7,11 +7,39 @@
 </head>
 <body>
 <div id="container">
+  <h6 id="globalOptionsHeader">Global Options:</h6>
   <form id="globalOptions">
-    <h6>Global Options:</h6>
+    <div class="option">
+      <input type="checkbox" id="usingWebAudio" name="usingWebAudio">
+      <label for="usingWebAudio">usingWebAudio</label>
+    </div>
+    <div class="option">
+      <input type="checkbox" id="noAudio" name="noAudio">
+      <label for="noAudio">noAudio</label>
+    </div>
+    <div class="option">
+      <input type="checkbox" id="autoUnlock" name="autoUnlock" checked>
+      <label for="autoUnlock">autoUnlock</label>
+    </div>
+    <div class="option">
+      <input type="number" id="html5PoolSize" name="html5PoolSize" min="1" max="10" value="10" style="width:2rem">
+      <label for="html5PoolSize">html5PoolSize</label>
+    </div>
+    <div class="option">
+      <input type="checkbox" id="autoSuspend" name="autoSuspend" checked>
+      <label for="autoSuspend">autoSuspend</label>
+    </div>
     <div class="option">
       <input type="checkbox" id="eagerPlayback" name="eagerPlayback">
-      <label for="eagerPlayback">Eager Playback</label>
+      <label for="eagerPlayback">eagerPlayback</label>
+    </div>
+    <div class="option">
+      <input type="checkbox" id="ctx" name="ctx">
+      <label for="ctx">ctx</label>
+    </div>
+    <div class="option">
+      <input type="checkbox" id="masterGain" name="masterGain">
+      <label for="masterGain">masterGain</label>
     </div>
   </form>
   <button class="button" id="webaudio">RUN WEB AUDIO TESTS</button>
@@ -21,10 +49,21 @@
 
 <script>
   function navigateToTest(testLocation) {
-    var globalOptionsEntries = new FormData(document.getElementById('globalOptions'));
-    var globalOptionsQueryString = [...globalOptionsEntries.keys()].map(key => `${key}=true`).join('&');
+    var formElements = document.getElementById('globalOptions').elements;
+    var globalOptionsElements = Array.prototype.slice.call(formElements, 0);
+    var globalOptions = globalOptionsElements.map(function(el) {
+      if (el.type === 'checkbox') {
+        return el.name + '=' + el.checked;
+      }
+
+      if (el.type === 'number' && el.value) {
+        var value = Math.max(el.min, Math.min(el.max, el.value))
+        return el.name + '=' + value;
+      }
+    });
+    var globalOptionsQueryString = globalOptions.filter(Boolean).join('&');
     window.location = globalOptionsQueryString.length
-      ? `${testLocation}?${globalOptionsQueryString}`
+      ? testLocation + '?' + globalOptionsQueryString
       : testLocation;
   }
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,28 +10,28 @@
   <h6 id="globalOptionsHeader">Global Options:</h6>
   <form id="globalOptions">
     <div class="option">
+      <label for="usingWebAudio">usingWebAudio:</label>
       <input type="checkbox" id="usingWebAudio" name="usingWebAudio" checked>
-      <label for="usingWebAudio">usingWebAudio</label>
     </div>
     <div class="option">
+      <label for="noAudio">noAudio:</label>
       <input type="checkbox" id="noAudio" name="noAudio">
-      <label for="noAudio">noAudio</label>
     </div>
     <div class="option">
+      <label for="autoUnlock">autoUnlock:</label>
       <input type="checkbox" id="autoUnlock" name="autoUnlock" checked>
-      <label for="autoUnlock">autoUnlock</label>
     </div>
     <div class="option">
+      <label for="html5PoolSize">html5PoolSize:</label>
       <input type="number" id="html5PoolSize" name="html5PoolSize" min="1" max="10" value="10" style="width:2rem">
-      <label for="html5PoolSize">html5PoolSize</label>
     </div>
     <div class="option">
+      <label for="autoSuspend">autoSuspend:</label>
       <input type="checkbox" id="autoSuspend" name="autoSuspend" checked>
-      <label for="autoSuspend">autoSuspend</label>
     </div>
     <div class="option">
+      <label for="eagerPlayback">eagerPlayback:</label>
       <input type="checkbox" id="eagerPlayback" name="eagerPlayback">
-      <label for="eagerPlayback">eagerPlayback</label>
     </div>
   </form>
   <button class="button" id="webaudio">RUN WEB AUDIO TESTS</button>

--- a/tests/index.html
+++ b/tests/index.html
@@ -33,14 +33,6 @@
       <input type="checkbox" id="eagerPlayback" name="eagerPlayback">
       <label for="eagerPlayback">eagerPlayback</label>
     </div>
-    <div class="option">
-      <input type="checkbox" id="ctx" name="ctx">
-      <label for="ctx">ctx</label>
-    </div>
-    <div class="option">
-      <input type="checkbox" id="masterGain" name="masterGain">
-      <label for="masterGain">masterGain</label>
-    </div>
   </form>
   <button class="button" id="webaudio">RUN WEB AUDIO TESTS</button>
   <button class="button" id="html5">RUN HTML5 TESTS</button>

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,7 +10,7 @@
   <h6 id="globalOptionsHeader">Global Options:</h6>
   <form id="globalOptions">
     <div class="option">
-      <input type="checkbox" id="usingWebAudio" name="usingWebAudio">
+      <input type="checkbox" id="usingWebAudio" name="usingWebAudio" checked>
       <label for="usingWebAudio">usingWebAudio</label>
     </div>
     <div class="option">

--- a/tests/index.html
+++ b/tests/index.html
@@ -6,24 +6,39 @@
   <link rel="stylesheet" href="./css/styles.css">
 </head>
 <body>
-  <div id="container">
-    <button class="button" id="webaudio">RUN WEB AUDIO TESTS</button>
-    <button class="button" id="html5">RUN HTML5 TESTS</button>
-    <button class="button" id="spatial">RUN SPATIAL TESTS</button>
-  </div>
+<div id="container">
+  <form id="globalOptions">
+    <h6>Global Options:</h6>
+    <div class="option">
+      <input type="checkbox" id="eagerPlayback" name="eagerPlayback">
+      <label for="eagerPlayback">Eager Playback</label>
+    </div>
+  </form>
+  <button class="button" id="webaudio">RUN WEB AUDIO TESTS</button>
+  <button class="button" id="html5">RUN HTML5 TESTS</button>
+  <button class="button" id="spatial">RUN SPATIAL TESTS</button>
+</div>
 
-  <script>
-    document.getElementById('webaudio').onclick = function() {
-      window.location = 'core.webaudio.html';
-    };
+<script>
+  function navigateToTest(testLocation) {
+    var globalOptionsEntries = new FormData(document.getElementById('globalOptions'));
+    var globalOptionsQueryString = [...globalOptionsEntries.keys()].map(key => `${key}=true`).join('&');
+    window.location = globalOptionsQueryString.length
+      ? `${testLocation}?${globalOptionsQueryString}`
+      : testLocation;
+  }
 
-    document.getElementById('html5').onclick = function() {
-      window.location = 'core.html5audio.html';
-    };
+  document.getElementById('webaudio').onclick = function() {
+    navigateToTest('core.webaudio.html');
+  };
 
-    document.getElementById('spatial').onclick = function() {
-      window.location = 'spatial.html';
-    };
-  </script>
+  document.getElementById('html5').onclick = function() {
+    navigateToTest('core.html5audio.html');
+  };
+
+  document.getElementById('spatial').onclick = function() {
+    navigateToTest('spatial.html');
+  };
+</script>
 </body>
 </html>

--- a/tests/js/core.html5audio.js
+++ b/tests/js/core.html5audio.js
@@ -1,3 +1,33 @@
+// Set global options from query params
+function parseValueFromEntry(entry) {
+  var [key, value] = entry;
+  var parsedValue = value;
+
+  if (value.toLowerCase() === 'true') {
+    parsedValue = true;
+  } else if (value.toLowerCase() === 'false') {
+    parsedValue = false;
+  } else if (!isNaN(value)) {
+    parsedValue = parseFloat(value);
+  }
+
+  return [key, parsedValue];
+}
+
+function setGlobalOptions([key, value]) {
+  if (Howler.hasOwnProperty(key)) {
+    Howler[key] = value;
+  }
+}
+
+window.location.search
+  .slice(1)
+  .split('&')
+  .filter(([key]) => key)
+  .map(pair => pair.split('='))
+  .map(parseValueFromEntry)
+  .forEach(setGlobalOptions);
+
 // Cache the label for later use.
 var label = document.getElementById('label');
 var start = document.getElementById('start');
@@ -30,11 +60,13 @@ sound1.once('load', function() {
 // Define the tests to run.
 var id;
 var tests = [
-   function(fn) {
-    id = sound1.play();
+  function(fn) {
+    sound1.once('play', function() {
+      label.innerHTML = 'PLAYING';
+      setTimeout(fn, 2000);
+    });
 
-    label.innerHTML = 'PLAYING';
-    setTimeout(fn, 2000);
+    id = sound1.play();
   },
 
   function(fn) {

--- a/tests/js/core.html5audio.js
+++ b/tests/js/core.html5audio.js
@@ -1,6 +1,7 @@
 // Set global options from query params
 function parseValueFromEntry(entry) {
-  var [key, value] = entry;
+  var key = entry[0];
+  var value = entry[1];
   var parsedValue = value;
 
   if (value.toLowerCase() === 'true') {
@@ -14,7 +15,10 @@ function parseValueFromEntry(entry) {
   return [key, parsedValue];
 }
 
-function setGlobalOptions([key, value]) {
+function setGlobalOptions(entry) {
+  var key = entry[0];
+  var value = entry[1];
+
   if (Howler.hasOwnProperty(key)) {
     Howler[key] = value;
   }
@@ -23,8 +27,8 @@ function setGlobalOptions([key, value]) {
 window.location.search
   .slice(1)
   .split('&')
-  .filter(([key]) => key)
-  .map(pair => pair.split('='))
+  .filter(function(entry) { return entry[0]; })
+  .map(function(pair) { return pair.split('='); })
   .map(parseValueFromEntry)
   .forEach(setGlobalOptions);
 

--- a/tests/js/core.html5audio.js
+++ b/tests/js/core.html5audio.js
@@ -1,37 +1,3 @@
-// Set global options from query params
-function parseValueFromEntry(entry) {
-  var key = entry[0];
-  var value = entry[1];
-  var parsedValue = value;
-
-  if (value.toLowerCase() === 'true') {
-    parsedValue = true;
-  } else if (value.toLowerCase() === 'false') {
-    parsedValue = false;
-  } else if (!isNaN(value)) {
-    parsedValue = parseFloat(value);
-  }
-
-  return [key, parsedValue];
-}
-
-function setGlobalOptions(entry) {
-  var key = entry[0];
-  var value = entry[1];
-
-  if (Howler.hasOwnProperty(key)) {
-    Howler[key] = value;
-  }
-}
-
-window.location.search
-  .slice(1)
-  .split('&')
-  .filter(function(entry) { return entry[0]; })
-  .map(function(pair) { return pair.split('='); })
-  .map(parseValueFromEntry)
-  .forEach(setGlobalOptions);
-
 // Cache the label for later use.
 var label = document.getElementById('label');
 var start = document.getElementById('start');

--- a/tests/js/core.webaudio.js
+++ b/tests/js/core.webaudio.js
@@ -1,3 +1,33 @@
+// Set global options from query params
+function parseValueFromEntry(entry) {
+  var [key, value] = entry;
+  var parsedValue = value;
+
+  if (value.toLowerCase() === 'true') {
+    parsedValue = true;
+  } else if (value.toLowerCase() === 'false') {
+    parsedValue = false;
+  } else if (!isNaN(value)) {
+    parsedValue = parseFloat(value);
+  }
+
+  return [key, parsedValue];
+}
+
+function setGlobalOptions([key, value]) {
+  if (Howler.hasOwnProperty(key)) {
+    Howler[key] = value;
+  }
+}
+
+window.location.search
+  .slice(1)
+  .split('&')
+  .filter(([key]) => key)
+  .map(pair => pair.split('='))
+  .map(parseValueFromEntry)
+  .forEach(setGlobalOptions);
+
 // Cache the label for later use.
 var label = document.getElementById('label');
 var start = document.getElementById('start');
@@ -33,7 +63,7 @@ var tests = [
       label.innerHTML = 'PLAYING';
       setTimeout(fn, 2000);
     });
-    
+
     id = sound1.play();
   },
 

--- a/tests/js/core.webaudio.js
+++ b/tests/js/core.webaudio.js
@@ -1,33 +1,3 @@
-// Set global options from query params
-function parseValueFromEntry(entry) {
-  var [key, value] = entry;
-  var parsedValue = value;
-
-  if (value.toLowerCase() === 'true') {
-    parsedValue = true;
-  } else if (value.toLowerCase() === 'false') {
-    parsedValue = false;
-  } else if (!isNaN(value)) {
-    parsedValue = parseFloat(value);
-  }
-
-  return [key, parsedValue];
-}
-
-function setGlobalOptions([key, value]) {
-  if (Howler.hasOwnProperty(key)) {
-    Howler[key] = value;
-  }
-}
-
-window.location.search
-  .slice(1)
-  .split('&')
-  .filter(([key]) => key)
-  .map(pair => pair.split('='))
-  .map(parseValueFromEntry)
-  .forEach(setGlobalOptions);
-
 // Cache the label for later use.
 var label = document.getElementById('label');
 var start = document.getElementById('start');

--- a/tests/js/parseGlobalOptions.js
+++ b/tests/js/parseGlobalOptions.js
@@ -1,0 +1,33 @@
+// Set global options from query params
+function parseValueFromEntry(entry) {
+  var key = entry[0];
+  var value = entry[1];
+  var parsedValue = value;
+
+  if (value.toLowerCase() === 'true') {
+    parsedValue = true;
+  } else if (value.toLowerCase() === 'false') {
+    parsedValue = false;
+  } else if (!isNaN(value)) {
+    parsedValue = parseFloat(value);
+  }
+
+  return [key, parsedValue];
+}
+
+function setGlobalOptions(entry) {
+  var key = entry[0];
+  var value = entry[1];
+
+  if (Howler.hasOwnProperty(key)) {
+    Howler[key] = value;
+  }
+}
+
+window.location.search
+  .slice(1)
+  .split('&')
+  .filter(function(entry) { return entry[0]; })
+  .map(function(pair) { return pair.split('='); })
+  .map(parseValueFromEntry)
+  .forEach(setGlobalOptions);

--- a/tests/js/spatial.js
+++ b/tests/js/spatial.js
@@ -1,3 +1,33 @@
+// Set global options from query params
+function parseValueFromEntry(entry) {
+  var [key, value] = entry;
+  var parsedValue = value;
+
+  if (value.toLowerCase() === 'true') {
+    parsedValue = true;
+  } else if (value.toLowerCase() === 'false') {
+    parsedValue = false;
+  } else if (!isNaN(value)) {
+    parsedValue = parseFloat(value);
+  }
+
+  return [key, parsedValue];
+}
+
+function setGlobalOptions([key, value]) {
+  if (Howler.hasOwnProperty(key)) {
+    Howler[key] = value;
+  }
+}
+
+window.location.search
+  .slice(1)
+  .split('&')
+  .filter(([key]) => key)
+  .map(pair => pair.split('='))
+  .map(parseValueFromEntry)
+  .forEach(setGlobalOptions);
+
 // Cache the label for later use.
 var label = document.getElementById('label');
 var start = document.getElementById('start');
@@ -33,7 +63,7 @@ var tests = [
       label.innerHTML = 'PLAYING';
       setTimeout(fn, 2000);
     });
-    
+
     id = sound1.play();
   },
 

--- a/tests/js/spatial.js
+++ b/tests/js/spatial.js
@@ -1,33 +1,3 @@
-// Set global options from query params
-function parseValueFromEntry(entry) {
-  var [key, value] = entry;
-  var parsedValue = value;
-
-  if (value.toLowerCase() === 'true') {
-    parsedValue = true;
-  } else if (value.toLowerCase() === 'false') {
-    parsedValue = false;
-  } else if (!isNaN(value)) {
-    parsedValue = parseFloat(value);
-  }
-
-  return [key, parsedValue];
-}
-
-function setGlobalOptions([key, value]) {
-  if (Howler.hasOwnProperty(key)) {
-    Howler[key] = value;
-  }
-}
-
-window.location.search
-  .slice(1)
-  .split('&')
-  .filter(([key]) => key)
-  .map(pair => pair.split('='))
-  .map(parseValueFromEntry)
-  .forEach(setGlobalOptions);
-
 // Cache the label for later use.
 var label = document.getElementById('label');
 var start = document.getElementById('start');

--- a/tests/spatial.html
+++ b/tests/spatial.html
@@ -12,6 +12,7 @@
   </div>
   <script src="../src/howler.core.js"></script>
   <script src="../src/plugins/howler.spatial.js"></script>
+  <script src="./js/parseGlobalOptions.js"></script>
   <script src="./js/spatial.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Issue/Feature
Add `eagerPlayback` global option to force `_canPlayEvent` to be set to `canplay`.  Useful for when business logic dictates that immediate playback takes precedence over potential audio buffering.

Additionally, using `canplay` exposes what seems to be a Chromium bug when setting `currentTime` on the node to the same value it's already set to. This bug is mitigated in this branch by wrapping the `currentTime` update in a conditional. See this CodePen example for a demo (see the `play()` function to adjust behavior): https://codepen.io/jbgomez/pen/jOYQeKQ

### Related Issues
https://github.com/goldfire/howler.js/issues/1072

### Solution
Adding opt-in `eagerPlayback` global option. Feature is disabled by default.

### Reproduction/Testing
Can be observed by measuring "time-to-tune" between `eagerPlayback` modes. When enabled, audio will begin playing relatively sooner. Test cases have been updated with the ability to set global options.

Chromium bug was reproduced on Chrome in macOS and Windows 10, as well as Edge on Windows 10.

### Breaking Changes
None.