### PR TITLE
Add an option to fully download the file before starting HTML5 stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Set to `true` to force HTML5 Audio. This should be used for large audio files so
 #### loop `Boolean` `false`
 Set to `true` to automatically loop the sound forever.
 #### preload `Boolean|String` `true`
-Automatically begin downloading the audio file when the `Howl` is defined. If using HTML5 Audio, you can set this to `'metadata'` to only preload the file's metadata (to get its duration without download the entire file, for example). 
+Automatically begin downloading the audio file when the `Howl` is defined. If using HTML5 Audio, you can set this to `'metadata'` to only preload the file's metadata (to get its duration without download the entire file, for example), or to `'full'` to download the whole file first before starting streaming.
 #### autoplay `Boolean` `false`
 Set to `true` to automatically start playback when sound is loaded.
 #### mute `Boolean` `false`


### PR DESCRIPTION
### Issue/Feature

Adds an option to fully download the file before starting HTML5 stream. This can be useful for use cases such as games that use many long background tracks, which are all downloaded before the game starts. Using Web Audio would cause huge memory footprint as all tracks get fully decoded after downloading. Using HTML5 streaming avoids that, but didn't allow to fully download the file beforehand, which now can be done by setting `preload` property to `full`.

### Solution

Setting `preload: 'full'` makes Howler download the file via XHR first, and then pass it to Audio object by using Blob object with `URL.createObjectURL`. The URL is then revoked when Howl is being unloaded.