### PR TITLE
Ensure the 'internal' flag is respected when calls to stop() function are enqueued

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -1084,7 +1084,7 @@
         self._queue.push({
           event: 'stop',
           action: function() {
-            self.stop(id);
+            self.stop(id, internal);
           }
         });
 


### PR DESCRIPTION
### Issue/Feature
I discovered a race condition when a looping HTML-backed clip would call `stop()` internally (when the clip naturally ends) and if the `playLock` happens to be `true` at that exact moment, then the `stop()` call gets added to the queue. However the `internal` flag was being dropped, which meant that I was then erroneously getting an `onstop` callback when the looping clip restarted. 

### Related Issues
None I can find

### Solution
The solution is to pass the `internal` flag on to the enqueued `stop()` function.

### Reproduction/Testing
I was able to reproduce reliably by starting several short looping clips in quick succession. At some point, if you log out the `onstop` callback, you'll see it being called when one of the clips reaches its end.

### Breaking Changes
N/A