### PR TITLE
Hotfix for backgrounded/suspended IOS issue

### DIFF
--- a/dist/howler.js
+++ b/dist/howler.js
@@ -521,7 +521,7 @@
       if (self.state === 'running' && self.ctx.state !== 'interrupted' && self._suspendTimer) {
         clearTimeout(self._suspendTimer);
         self._suspendTimer = null;
-      } else if (self.state === 'suspended' || self.state === 'running' && self.ctx.state === 'interrupted') {
+      } else if (self.state === 'suspended' || self.state === 'running' || self.state === 'suspending') {
         self.ctx.resume().then(function() {
           self.state = 'running';
 
@@ -535,8 +535,6 @@
           clearTimeout(self._suspendTimer);
           self._suspendTimer = null;
         }
-      } else if (self.state === 'suspending') {
-        self._resumeAfterSuspend = true;
       }
 
       return self;

--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -521,7 +521,7 @@
       if (self.state === 'running' && self.ctx.state !== 'interrupted' && self._suspendTimer) {
         clearTimeout(self._suspendTimer);
         self._suspendTimer = null;
-      } else if (self.state === 'suspended' || self.state === 'running' && self.ctx.state === 'interrupted') {
+      } else if (self.state === 'suspended' || self.state === 'running' || self.state === 'suspending') {
         self.ctx.resume().then(function() {
           self.state = 'running';
 
@@ -535,8 +535,6 @@
           clearTimeout(self._suspendTimer);
           self._suspendTimer = null;
         }
-      } else if (self.state === 'suspending') {
-        self._resumeAfterSuspend = true;
       }
 
       return self;


### PR DESCRIPTION
- Verified working on IOS 14/15/16
- Doesn't fix core of the issue, which is - on IOS we end up in the 'suspending' state when backgrounding an app, but the logic for resuming the context while 'suspending' is based on a 30 second timer that may or may not get hit depending on how long you have it backgrounded for.

### Issue/Feature
Issue was that after a certain amount of time after backgrounding the app and then coming back (~10-40 secs), audio would be forever muted.

### Related Issues

### Solution

### Reproduction/Testing
On IOS 14/15/16, background an app using Howler for 10/20/30/40/50 seconds, and then return to that app and observe if audio is working or not.

### Breaking Changes
This could break instances where the state is 'running' and we should not be resuming the context because the state is not interrupted, but I haven't seen this happen yet in testing.