### PR TITLE
Fix issue with SSR

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -2572,16 +2572,8 @@
     exports.Howl = Howl;
   }
 
-  // Add to global in Node.js (for testing, etc).
-  if (typeof global !== 'undefined') {
-    global.HowlerGlobal = HowlerGlobal;
-    global.Howler = Howler;
-    global.Howl = Howl;
-    global.Sound = Sound;
-  } else if (typeof window !== 'undefined') {  // Define globally in case AMD is not available or unused.
-    window.HowlerGlobal = HowlerGlobal;
-    window.Howler = Howler;
-    window.Howl = Howl;
-    window.Sound = Sound;
-  }
+  globalThis.HowlerGlobal = HowlerGlobal;
+  globalThis.Howler = Howler;
+  globalThis.Howl = Howl;
+  globalThis.Sound = Sound;
 })();


### PR DESCRIPTION
### Issue/Feature
SSR (especially in Svelte) results in a 500 since the old if/else clause patches the wrong global object

### Solution
instead of explicitly using `window` or `global`, `globalThis` is [the universal global object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis)