### PR TITLE
Fix NW.JS compatibility

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -2578,7 +2578,8 @@
     global.Howler = Howler;
     global.Howl = Howl;
     global.Sound = Sound;
-  } else if (typeof window !== 'undefined') {  // Define globally in case AMD is not available or unused.
+  }
+  if (typeof window !== 'undefined') {  // Define globally in case AMD is not available or unused.
     window.HowlerGlobal = HowlerGlobal;
     window.Howler = Howler;
     window.Howl = Howl;


### PR DESCRIPTION
When running on NW, Howler mistakenly detects the environment as Node.js, breaking pure web apps on the platform. By removing the else statement, the Howler object is available in both the global AND the window context.

### Issue/Feature
<!--
  Describe the issue/feature resolved by this PR.
  If a new feature, explain why this should be included in the core library.
-->

### Related Issues
<!-- Link to any related issues here. -->

### Solution
<!-- Describe the solution provided in this PR. -->

### Reproduction/Testing
<!--
  Describe the steps to test for the issue to confirm that this PR resolves it.
  Or, if this is a new feature, how to test the new feature.
-->

### Breaking Changes
<!-- Describe any breaking changes that this introduces and the migration path for existing applications. -->
N/A