### PR TITLE
Update howler.core.js

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -269,7 +269,8 @@
       var isOldOpera = (checkOpera && parseInt(checkOpera[0].split('/')[1], 10) < 33);
       var checkSafari = ua.indexOf('Safari') !== -1 && ua.indexOf('Chrome') === -1;
       var safariVersion = ua.match(/Version\/(.*?) /);
-      var isOldSafari = (checkSafari && safariVersion && parseInt(safariVersion[1], 10) < 15);
+      // iOS version 16+ doesn't play the html5 sound sometimes, so we need to check for it.
+      var isOldSafari = (checkSafari && safariVersion && parseInt(safariVersion[1], 10) < 18);
 
       self._codecs = {
         mp3: !!(!isOldOpera && (mpegTest || audioTest.canPlayType('audio/mp3;').replace(/^no$/, ''))),


### PR DESCRIPTION
iOS 16+ doesn't play html5 sounds sometimes hence a fix has been done at line number 273 which fixed the issue at my end.
