### PR TITLE
Fixed the issue of music not playing in iOS 14.0

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -486,6 +486,12 @@
           return;
         }
 
+        // Fixed the issue of music not playing in iOS 14.0 30s, 
+        // and music can no longer be played after that·
+        if (self.ctx.state === "suspended") {
+          return;
+        }
+
         self._suspendTimer = null;
         self.state = 'suspending';
 


### PR DESCRIPTION
Fixed the issue of music not playing in iOS 14.0 30s, and music can no longer be played after that