### PR TITLE
Use the MediaError message attribute if available

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -2313,7 +2313,7 @@
       var self = this;
 
       // Fire an error event and pass back the code.
-      self._parent._emit('loaderror', self._id, self._node.error ? self._node.error.code : 0);
+      self._parent._emit('loaderror', self._id, self._node.error ? self._node.error.message || self._node.error.code : 0);
 
       // Clear the event listener.
       self._node.removeEventListener('error', self._errorFn, false);


### PR DESCRIPTION


### Issue/Feature

Prefer the `message` attribute on the error over the `code` attribute because it contains more specific diagnostic information.

### Related Issues
<!-- Link to any related issues here. -->

I couldn't find any.

### Solution
<!-- Describe the solution provided in this PR. -->

The `message` attribute on the `MediaError` object returned by `HTMLMediaElement.error` contains specific diagnostic details about the error if available, or an empty string otherwise.

If this message is available then it will be passed with the `loaderror`, otherwise the code will be passed as before.

See https://html.spec.whatwg.org/multipage/media.html#error-codes.

### Reproduction/Testing
<!--
  Describe the steps to test for the issue to confirm that this PR resolves it.
  Or, if this is a new feature, how to test the new feature.
-->

Trigger a media error, and observe that a string message is provided to `onloaderror` instead of a code.

The easiest option is to use a non-existent source:

```js
const howl = new Howl({
  src: 'non-existent.webm',
  html5: true,
  onloaderror(id, error) {
    console.log(error)
  },
})
howl.play()
```

Which will print something like `Failed to init decoder` instead of `4`.

### Breaking Changes
<!-- Describe any breaking changes that this introduces and the migration path for existing applications. -->

The `onloaderror` was already being called with a message in most cases, so I wouldn't consider this a breaking change.