### PR TITLE
Added a loadheaders callback

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -608,6 +608,7 @@
       self._onend = o.onend ? [{fn: o.onend}] : [];
       self._onfade = o.onfade ? [{fn: o.onfade}] : [];
       self._onload = o.onload ? [{fn: o.onload}] : [];
+      self._onloadheaders = o.onloadheaders ? [{fn: o.onloadheaders}] : [];
       self._onloaderror = o.onloaderror ? [{fn: o.onloaderror}] : [];
       self._onplayerror = o.onplayerror ? [{fn: o.onplayerror}] : [];
       self._onpause = o.onpause ? [{fn: o.onpause}] : [];
@@ -2424,7 +2425,8 @@
           self._emit('loaderror', null, 'Failed loading audio file with status: ' + xhr.status + '.');
           return;
         }
-
+        // send a ccopy of the headers we got from teh network request back as a callback.
+        self._emit('loadheaders', xhr.getAllResponseHeaders());
         decodeAudioData(xhr.response, self);
       };
       xhr.onerror = function() {


### PR DESCRIPTION
This callback allows a callback hook to the developer, for them to be able to examine the request headers. This allows for extra header information to be passed related to the audio file for post processing.

### Issue/Feature
<!--
  Describe the issue/feature resolved by this PR.
  If a new feature, explain why this should be included in the core library.
-->

### Related Issues
<!-- Link to any related issues here. -->

### Solution
<!-- Describe the solution provided in this PR. -->

### Reproduction/Testing
<!--
  Describe the steps to test for the issue to confirm that this PR resolves it.
  Or, if this is a new feature, how to test the new feature.
-->

### Breaking Changes
<!-- Describe any breaking changes that this introduces and the migration path for existing applications. -->
N/A