### PR TITLE
Fix duplicationg audio on refresh

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -885,7 +885,7 @@
 
         if (Howler.state === 'running' && Howler.ctx.state !== 'interrupted') {
           playWebAudio();
-        } else {
+        } else if (!self._playLock) {
           self._playLock = true;
 
           // Wait for the audio context to resume before playing.


### PR DESCRIPTION
### Issue/Feature
If a user is loading a game which uses Howler, and they lose focus on the page during load, and then come back to the page at a later state, there is a good chance that Howler may produce duplicate sounds with unpredictable behaviour. If the user does not have focus on the game, our game engine for instance, will pause the game (including sounds) as soon as it finishes loading.

### Related Issues
https://github.com/goldfire/howler.js/issues/950