### PR TITLE
Fix race condition when calling play() just right after pause() on iOS

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -977,7 +977,8 @@
         // Play immediately if ready, or wait for the 'canplaythrough'e vent.
         var loadedNoReadyState = (window && window.ejecta) || (!node.readyState && Howler._navigator.isCocoonJS);
         if (node.readyState >= 3 || loadedNoReadyState) {
-          playHtml5();
+          // when play() is called just after pause(), there is a race causing audio node to pause immediately after play on iOS
+          setTimeout(playHtml5, 0);
         } else {
           self._playLock = true;
           self._state = 'loading';


### PR DESCRIPTION
### Issue/Feature
Fix race condition when calling play() just right after pause() on iOS

On iOS, a looping sound with html5:true fails to loop intermittently.


### Related Issues
<!-- Link to any related issues here. -->

### Solution

Calling play() in next macro task by wrapping `playHtml5` in `setTimeout`

### Reproduction/Testing

I can reproduce the bug pretty frequently with somewhat long audio file.


### Breaking Changes
<!-- Describe any breaking changes that this introduces and the migration path for existing applications. -->
N/A